### PR TITLE
spu_franxis audio plugin spu fixes

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -587,7 +587,12 @@ static const char PcsxHeader[32] = "STv4 PCSX v" PACKAGE_VERSION;
 
 // Savestate Versioning!
 // If you make changes to the savestate version, please increment the value below.
-static const u32 SaveVersion = 0x8b410004;
+
+//senquack - had to increment version value as requested above, after fixing buffer-size
+//			 return value of of SPU_freeze() in spu/spu_franxis/spu.cpp.
+//static const u32 SaveVersion = 0x8b410004;
+static const u32 SaveVersion = 0x8b410005;
+
 #define FWRITE(c,a,b) fwrite(a,sizeof(u8),b,c)
 int SaveState(const char *file) {
     FILE* f;

--- a/src/spu/spu_franxis/spu.cpp
+++ b/src/spu/spu_franxis/spu.cpp
@@ -401,7 +401,7 @@ long SPU_init(void)
 	spuMemC=(unsigned char *)spuMem;                      // just small setup
 	if (!nullspu)
 	{
-        //senquack - smarter way to zero-fill array:
+		//senquack - smarter way to zero-fill array:
 		//memset((void *)s_chan,0,MAXCHAN*sizeof(SPUCHAN));
 		memset((void *)s_chan,0,sizeof(s_chan));
 
@@ -411,7 +411,7 @@ long SPU_init(void)
 		spuAddr = 0xffffffff;
 		spuMemC = (unsigned char *)spuMem;
 
-        //senquack - buffer overflow and redundant fill of 0 (already filled above)
+		//senquack - buffer overflow and redundant fill of 0 (already filled above)
 		//memset((void *)s_chan, 0, (MAXCHAN + 1) * sizeof(SPUCHAN));
 
 		pSpuIrq = 0;
@@ -420,7 +420,7 @@ long SPU_init(void)
 
 		SetupStreams();                                       // prepare streaming
 
-        //senquack - smarter way to zero-fill array:
+		//senquack - smarter way to zero-fill array:
 		//memset(SSumL,0,NSSIZE*sizeof(int));
 		//memset(iFMod,0,NSSIZE*sizeof(int));
 		memset(SSumL,0,sizeof(SSumL));
@@ -537,14 +537,28 @@ long SPU_freeze(uint32_t ulFreezeMode,SPUFreeze_t * pF)
 
 	if(ulFreezeMode)                                      // info or save?
 	{//--------------------------------------------------//
+		//senquack - this is not OK! SaveState() in src/misc.cpp first calls this function with
+		// ulFreezeMode==2, expecting this function to setulFreezeSize struct member to the
+		// total size of memory to allocate for SPU's portion of save-state file. It allocates
+		// the requested buffer size, and then calls here again with ulFreezeMode==1. So, this
+		// function was causing very undefined behavior with original line below:
+
+		// if(ulFreezeMode==2) return 1;                       // info mode? ok, bye
+
+		// senquack - Replacement for above line:
+        if (ulFreezeMode==2) {
+            // Caller wants to know total buffer size to allocate:
+            pF->ulFreezeSize = sizeof(SPUFreeze_t)+sizeof(SPUOSSFreeze_t);
+            return 1;
+        }
+
 		if(ulFreezeMode==1)                                 
-		memset(pF,0,sizeof(SPUFreeze_t)+sizeof(SPUOSSFreeze_t));
+            memset(pF,0,sizeof(SPUFreeze_t)+sizeof(SPUOSSFreeze_t));
 
 		strcpy(pF->szSPUName,"PBOSS");
 		pF->ulFreezeVersion=5;
 		pF->ulFreezeSize=sizeof(SPUFreeze_t)+sizeof(SPUOSSFreeze_t);
 
-		if(ulFreezeMode==2) return 1;                       // info mode? ok, bye
 		// save mode:
 		memcpy(pF->cSPURam,spuMem,0x80000);                 // copy common infos
 		memcpy(pF->cSPUPort,regArea,0x200);
@@ -581,8 +595,12 @@ long SPU_freeze(uint32_t ulFreezeMode,SPUFreeze_t * pF)
 			pFO->s_chan[i].pLoop-=(unsigned long)spuMemC;
 		}
 
-		memset(SSumL,0,NSSIZE*sizeof(int));
-		memset(iFMod,0,NSSIZE*sizeof(int));
+		//senquack - smarter way to zero-fill array:
+		//memset(SSumL,0,NSSIZE*sizeof(int));
+		//memset(iFMod,0,NSSIZE*sizeof(int));
+		memset(SSumL,0,sizeof(SSumL));
+		memset(iFMod,0,sizeof(iFMod));
+
 		pS=(short *)(void *)pSpuBuffer;                               // setup soundbuffer pointer
 
 		return 1;
@@ -624,8 +642,12 @@ long SPU_freeze(uint32_t ulFreezeMode,SPUFreeze_t * pF)
 	// fix to prevent new interpolations from crashing
 	for(i=0;i<MAXCHAN;i++) s_chan[i].SB[28]=0;
 
-	memset(SSumL,0,NSSIZE*sizeof(int));
-	memset(iFMod,0,NSSIZE*sizeof(int));
+	//senquack - smarter way to zero-fill array:
+	//memset(SSumL,0,NSSIZE*sizeof(int));
+	//memset(iFMod,0,NSSIZE*sizeof(int));
+	memset(SSumL,0,sizeof(SSumL));
+	memset(iFMod,0,sizeof(iFMod));
+
 	pS=(short *)(void *)pSpuBuffer;                               // setup soundbuffer pointer
 
 	return 1;

--- a/src/spu/spu_franxis/spu.cpp
+++ b/src/spu/spu_franxis/spu.cpp
@@ -40,11 +40,11 @@ SPUCHAN         s_chan[MAXCHAN+1];                     // channel + 1 infos (1 i
 unsigned short  spuCtrl=0;                             // some vars to store psx reg infos
 unsigned short  spuStat=0;
 unsigned short  spuIrq=0;
-unsigned long   spuAddr=0xffffffff;                    // address into spu mem
+unsigned int   spuAddr=0xffffffff;                    // address into spu mem
 
 unsigned int dwNewChannel=0;                           // flags for faster testing, if new channel starts
 unsigned int dwChannelOn=0;
-unsigned long dwPendingChanOff=0;
+unsigned int dwPendingChanOff=0;
 
 // certain globals (were local before, but with the new timeproc I need em global)
 
@@ -401,21 +401,31 @@ long SPU_init(void)
 	spuMemC=(unsigned char *)spuMem;                      // just small setup
 	if (!nullspu)
 	{
-		memset((void *)s_chan,0,MAXCHAN*sizeof(SPUCHAN));
+        //senquack - smarter way to zero-fill array:
+		//memset((void *)s_chan,0,MAXCHAN*sizeof(SPUCHAN));
+		memset((void *)s_chan,0,sizeof(s_chan));
+
 		InitADSR();
 
 		spuIrq = 0;
 		spuAddr = 0xffffffff;
 		spuMemC = (unsigned char *)spuMem;
-		memset((void *)s_chan, 0, (MAXCHAN + 1) * sizeof(SPUCHAN));
+
+        //senquack - buffer overflow and redundant fill of 0 (already filled above)
+		//memset((void *)s_chan, 0, (MAXCHAN + 1) * sizeof(SPUCHAN));
+
 		pSpuIrq = 0;
 
 		sound_init();                                         // setup sound (before init!)
 
 		SetupStreams();                                       // prepare streaming
 
-		memset(SSumL,0,NSSIZE*sizeof(int));
-		memset(iFMod,0,NSSIZE*sizeof(int));
+        //senquack - smarter way to zero-fill array:
+		//memset(SSumL,0,NSSIZE*sizeof(int));
+		//memset(iFMod,0,NSSIZE*sizeof(int));
+		memset(SSumL,0,sizeof(SSumL));
+		memset(iFMod,0,sizeof(iFMod));
+
 		pS=(short *)(void *)pSpuBuffer;                               // setup soundbuffer pointer
 	}
 	return 0;

--- a/src/spu/spu_franxis/spu.h
+++ b/src/spu/spu_franxis/spu.h
@@ -34,7 +34,9 @@
 
 typedef struct
 {
-	long	y0, y1;
+	//senquack - fixed mismatch with actual type used in emulator on 64-bit platforms:
+	//long	y0, y1;
+	s32	y0, y1;
 } ADPCM_Decode_t;
 
 typedef struct
@@ -247,7 +249,7 @@ extern SPUCHAN s_chan[];
 extern unsigned short spuCtrl;
 extern unsigned short spuStat;
 extern unsigned short spuIrq;
-extern unsigned long  spuAddr;
+extern unsigned int  spuAddr;
 extern unsigned int dwNewChannel;
 extern unsigned int dwChannelOn;
 

--- a/src/spu/spu_franxis/spu_adsr.h
+++ b/src/spu/spu_franxis/spu_adsr.h
@@ -28,7 +28,9 @@ INLINE void InitADSR(void)                                    // INIT ADSR
 {
  unsigned int r,rs,rd;int i;
 
-	memset(RateTable,0,sizeof(unsigned long)*160);        // build the rate table according to Neill's rules (see at bottom of file)
+	//senquack - fixed buffer overflow on 64-bit platforms:
+	//memset(RateTable,0,sizeof(unsigned long)*160);        // build the rate table according to Neill's rules (see at bottom of file)
+	memset(RateTable,0,sizeof(RateTable));        // build the rate table according to Neill's rules (see at bottom of file)
 
 	r=3;rs=1;rd=0;
 

--- a/src/spu/spu_franxis/spu_regs.h
+++ b/src/spu/spu_franxis/spu_regs.h
@@ -217,7 +217,7 @@ void SPU_writeRegister(unsigned long reg, unsigned short val)
 
 	switch(r)
 	{
-	case H_SPUaddr: spuAddr = (unsigned long) val<<3; break;
+	case H_SPUaddr: spuAddr = (unsigned int) val<<3; break;
 	case H_SPUdata: spuMem[spuAddr>>1] = val; spuAddr+=2; if(spuAddr>0x7ffff) spuAddr=0; break;
 	case H_SPUctrl: spuCtrl=val; break;
 	case H_SPUstat: spuStat=val & 0xf800; break;

--- a/src/spu/spu_franxis/spu_xa.h
+++ b/src/spu/spu_franxis/spu_xa.h
@@ -175,7 +175,7 @@ INLINE void FeedCDDA(unsigned char *pcm, int nBytes)
 	uint16_t *feed=CDDAFeed;
 	uint16_t *start=CDDAStart;
 	uint16_t *end=CDDAEnd;
-	if ((unsigned int)pcm&1)
+	if ((unsigned long)pcm&1)
 	{
 		while(nBytes>0)
 		{


### PR DESCRIPTION
- Fixed several buffer overflows in Franxis's SPU plugin.
- When compiling for x64, fixed mismatch types in SPU's declarations of emu<->SPU structs that had long data types instead of unsigned int.
- Fixed major bug in save-state saving in SPU plugin.
- Misc little fixes