### PR TITLE
XA audio improvements

### DIFF
--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -576,7 +576,10 @@ int main (int argc, char **argv)
 		//senquack - Added option to allow queuing CDREAD_INT interrupts sooner
 		//           than they'd normally be issued when SPU's XA buffer is not
 		//           full. This fixes droupouts in music/speech on slow devices.
-		if (strcmp(argv[i],"-noforcedxaupdates")==0) Config.ForcedXAUpdates=0;
+		if (strcmp(argv[i],"-noforcedxaupdates")==0) {
+			printf("Forced XA audio updates are disabled.\n");
+			Config.ForcedXAUpdates=0;
+		}
 
 		// GPU
 	#ifdef gpu_dfxvideo

--- a/src/psxcounters.cpp
+++ b/src/psxcounters.cpp
@@ -279,9 +279,19 @@ void psxRcntUpdate()
 		//NOTE AND TODO: in PCSX_ReARMed, it always compares hSyncCount to 240, regardless of
 		//				 type of PSX being emulated, i.e. PAL would be 256 I think versus 
 		//				 NTSC vblank at 240????
-        if (hSyncCount == 240)								// Original PCSX_ReARMed behavior
-        //if (hSyncCount == VBlankStart[Config.PsxType])	// What *might* be more correct behavior -senquack
+        //if (hSyncCount == 240)								// Original PCSX_ReARMed behavior
+        ////if (hSyncCount == VBlankStart[Config.PsxType])	// What *might* be more correct behavior -senquack
+        //    SPU_async( cycle, 1 );
+		//senquack - Calling SPU_async() at such an infrequent interval as above
+		// causes audio dropouts on slow devices like GCW. I've made it update
+		// twice as often for now.
+		//TODO: Frequency of updates might need to be configurable if we ever
+		// use video output with VSYNC enabled, for instance GCW Zero's GLES
+		// driver demands it. That might cause frame rate to drop to 30,
+		// making audio drop out again even after the change below..
+        if (hSyncCount == 120 || hSyncCount == 240)
             SPU_async( cycle, 1 );
+
 #else
         // Update spu.
         spuSyncCount++;

--- a/src/spu/spu_pcsxrearmed/externals.h
+++ b/src/spu/spu_pcsxrearmed/externals.h
@@ -209,6 +209,9 @@ typedef struct
  unsigned int  * XAPlay;
  unsigned int  * XAStart;
  unsigned int  * XAEnd;
+ //senquack - Added this, see new function SPU_getADPCMBufferRoom() in
+ // spu_pcsxrearmed_wrapper.h and UpdateXABufferRoom() in xa.c
+ unsigned int    XABufferRoom;
 
  unsigned int  * CDDAFeed;
  unsigned int  * CDDAPlay;

--- a/src/spu/spu_pcsxrearmed/sdl.c
+++ b/src/spu/spu_pcsxrearmed/sdl.c
@@ -98,8 +98,10 @@ static void SOUND_FillAudio_Atomic(void *unused, Uint8 *stream, int len) {
 	}
 
 	// If the callback asked for more samples than we had, zero-fill remainder:
-	if (len - bytes_to_copy > 0)
+	if (len - bytes_to_copy > 0) {
 		memset(out_buf + bytes_to_copy, 0, len - bytes_to_copy);
+		//printf("SDL audio callback underrun by %d bytes\n", len - bytes_to_copy);
+	}
 
 	// Signal emu thread that room is available:
 	if (waiting_to_feed)

--- a/src/spu/spu_pcsxrearmed/spu.c
+++ b/src/spu/spu_pcsxrearmed/spu.c
@@ -1337,6 +1337,8 @@ static void SetupStreams(void)
  spu.XAEnd   = spu.XAStart + 44100;
  spu.XAPlay  = spu.XAStart;
  spu.XAFeed  = spu.XAStart;
+ //senquack - Added UpdateXABufferRoom in xa.c:
+ UpdateXABufferRoom();
 
  spu.CDDAStart =                                       // alloc cdda buffer
   (uint32_t *)malloc(CDDA_BUFFER_SIZE);

--- a/src/spu/spu_pcsxrearmed/spu.c
+++ b/src/spu/spu_pcsxrearmed/spu.c
@@ -1310,6 +1310,17 @@ void CALLBACK SPUplayADPCMchannel(xa_decode_t *xap)
  FeedXA(xap);                                          // call main XA feeder
 }
 
+//senquack - Added function to tell how much room is free in XA audio buffer,
+//           in number of stereo samples. It is used by cdrReadInterrupt()
+//           in cdrom.cpp to determine if a CDREAD_INT interrupt should be
+//           scheduled sooner than normal faster, to keep buffer full.
+//           See notes there and in xa.c for UpdateXABufferRoom().
+unsigned int CALLBACK SPUgetADPCMBufferRoom()
+{
+   return spu.XABufferRoom;
+}
+
+
 // CDDA AUDIO
 int CALLBACK SPUplayCDDAchannel(short *pcm, int nbytes)
 {

--- a/src/spu/spu_pcsxrearmed/spu_pcsxrearmed_wrapper.h
+++ b/src/spu/spu_pcsxrearmed/spu_pcsxrearmed_wrapper.h
@@ -43,6 +43,7 @@ extern unsigned short SPUreadDMA(void);
 extern void SPUwriteDMAMem(unsigned short *, int, unsigned int);
 extern void SPUreadDMAMem(unsigned short *, int, unsigned int);
 extern void SPUplayADPCMchannel(xa_decode_t *);
+extern unsigned int SPUgetADPCMBufferRoom(); //senquack - added function
 extern int  SPUplayCDDAchannel(short *, int);
 extern void SPUregisterCallback(void (CALLBACK *callback)(void));
 extern void SPUregisterScheduleCb(void (CALLBACK *callback)(unsigned int cycles_after));
@@ -139,14 +140,18 @@ static inline void SPU_readDMAMem(unsigned short *pusPSXMem, int iSize)
     SPUreadDMAMem(pusPSXMem, iSize, *psxRegs_cycle_valptr);
 }
 
-//senquack - TODO: perhaps this should provide feedback the same way the CDDA
-//                 function below it does, to avoid dropped XA frames.
-//                 Notaz didn't add similar feedback retval to his ADPCM function,
-//                 though, and I wonder why. Looking at cdriso.cpp, frames might be
-//                 dropped when XAbuffer[] is full, and caller perhaps doesn't know.
 static inline void SPU_playADPCMchannel(xa_decode_t *xap)
 {
     SPUplayADPCMchannel(xap);
+}
+
+// senquack - I added this function when fixing XA audio dropouts on
+//            slower devices/games. (used in cdrom.cpp, see notes
+//            for cdrReadInterrupt() there or UpdateXABufferRoom() and
+//            FeedXA() in xa.c
+static inline unsigned int SPU_getADPCMBufferRoom()
+{
+	return SPUgetADPCMBufferRoom();
 }
 
 //senquack - note how Notaz's SPU_playCDDAchannel() now returns a feedback value


### PR DESCRIPTION
XA audio (music/speech) on slow devices was suffering dropouts. It turns out the problem was two-fold:
- CDREAD_INT interrupts were being issued at same or slower rate than it would take to keep buffer filled. If a game cannot run 100% fullspeed, dropouts were inevitable.
- Even when said interrupts were issued sooner when buffer wasn't full, XA buffer in spu_pcsxrearmed would never fill more than one frame of audio.

Fix:
- Added new function SPU_getADPCMBufferRoom() and XABufferRoom variable, used to determine if XA buffer isn't full and to issue a CDREAD_INT twice as soon as normal to keep it full. 'Config.ForcedXAUpdates' option can be set to 0 if original behavior is desired, set through the new commandline  '-noforcedxaupdates' flag.
- FeedXA() in spu_pcsxrearmed/xa.c uses new method of determining available buffer space