### PR TITLE
Gpu_unai bug fixes

### DIFF
--- a/src/gpu/gpu_unai/gpu.cpp
+++ b/src/gpu/gpu_unai/gpu.cpp
@@ -465,7 +465,9 @@ void  GPU_readDataMem(u32* dmaAddress, s32 dmaCount)
 	{
 		if ((&pvram[px])>(VIDEO_END)) pvram-=512*1024;
 		// lower 16 bit
-		u32 data = (unsigned long)pvram[px];
+		//senquack - 64-bit fix (from notaz)
+		//u32 data = (unsigned long)pvram[px];
+		u32 data = (u32)pvram[px];
 
 		if (++px>=x_end) 
 		{
@@ -475,7 +477,9 @@ void  GPU_readDataMem(u32* dmaAddress, s32 dmaCount)
 
 		if ((&pvram[px])>(VIDEO_END)) pvram-=512*1024;
 		// higher 16 bit (always, even if it's an odd width)
-		data |= (unsigned long)(pvram[px])<<16;
+		//senquack - 64-bit fix (from notaz)
+		//data |= (unsigned long)(pvram[px])<<16;
+		data |= (u32)(pvram[px])<<16;
 		
 		*dmaAddress++ = data;
 

--- a/src/gpu/gpu_unai/gpu_command.h
+++ b/src/gpu/gpu_unai/gpu_command.h
@@ -27,7 +27,12 @@ INLINE void gpuSetTexture(u16 tpage)
 	u32 tp;
 	u32 tx, ty;
 
-	GPU_GP1 = (GPU_GP1 & ~0x7FF) | (tpage & 0x7FF);
+	//senquack - From Notaz's '64-bit issues' commit, he changed the following,
+	//           in pcsx_rearmed's gpu_unai, but there was no associated comment.
+	//           This fix makes Unai's code match gpu_drhell's GPU code
+	// https://github.com/notaz/pcsx_rearmed/commit/4144e9abc1fb8420e08e0a5ef48a9ceba7f26661
+	//GPU_GP1 = (GPU_GP1 & ~0x7FF) | (tpage & 0x7FF);
+	GPU_GP1 = (GPU_GP1 & ~0x1FF) | (tpage & 0x1FF);
 
 	TextureWindow[0]&= ~TextureWindow[2];
 	TextureWindow[1]&= ~TextureWindow[3];
@@ -35,6 +40,12 @@ INLINE void gpuSetTexture(u16 tpage)
 	tp = (tpage >> 7) & 3;
 	tx = (tpage & 0x0F) << 6;
 	ty = (tpage & 0x10) << 4;
+
+	//senquack - Added this line from same commit by Notaz as above comment mentions:
+	//           As you can see from 'tx += ' line just below the added line, it
+	//           would be shifting by undefined amount should tp equal a value
+	//           more than 2, so I suppose this is a good check to do.
+	if (tp == 3) tp = 2;
 
 	tx += (TextureWindow[0] >> (2 - tp));
 	ty += TextureWindow[1];

--- a/src/gpu/gpu_unai/gpu_command.h
+++ b/src/gpu/gpu_unai/gpu_command.h
@@ -21,8 +21,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 INLINE void gpuSetTexture(u16 tpage)
 {
-	long tp;
-	long tx, ty;
+	//senquack - 64-bit fix (from Notaz)
+	//long tp;
+	//long tx, ty;
+	u32 tp;
+	u32 tx, ty;
+
 	GPU_GP1 = (GPU_GP1 & ~0x7FF) | (tpage & 0x7FF);
 
 	TextureWindow[0]&= ~TextureWindow[2];
@@ -461,8 +465,11 @@ void gpuSendPacketFunction(const int PRIM)
 		case 0xE5:
 			{
 				const u32 temp = PacketBuffer.U4[0];
-				DrawingOffset[0] = ((long)temp<<(32-11))>>(32-11);
-				DrawingOffset[1] = ((long)temp<<(32-22))>>(32-11);
+				//senquack - 64-bit fix from Notaz:
+				//DrawingOffset[0] = ((long)temp<<(32-11))>>(32-11);
+				//DrawingOffset[1] = ((long)temp<<(32-22))>>(32-11);
+				DrawingOffset[0] = ((s32)temp<<(32-11))>>(32-11);
+				DrawingOffset[1] = ((s32)temp<<(32-22))>>(32-11);
 				DO_LOG(("DrawingOffset(0x%x)\n",PRIM));
 			}
 			break;

--- a/src/gpu/gpu_unai/gpu_fixedpoint.h
+++ b/src/gpu/gpu_unai/gpu_fixedpoint.h
@@ -38,7 +38,8 @@ s32 s_invTable[(1<<TABLE_BITS)];
 INLINE  fixed i2x(const int   _x) { return  ((_x)<<FIXED_BITS); }
 INLINE  fixed x2i(const fixed _x) { return  ((_x)>>FIXED_BITS); }
 
-#ifdef __arm__
+//senquack - MIPS32 happens to have same instruction/format:
+#if defined(__arm__) || (__mips == 32)
 INLINE u32 Log2(u32 x) { u32 res; asm("clz %0,%1" : "=r" (res) : "r" (x)); return 32-res; }
 #else
 INLINE u32 Log2(u32 x) { u32 i = 0; for ( ; x > 0; ++i, x >>= 1); return i - 1; }

--- a/src/gpu/gpu_unai/gpu_raster_line.h
+++ b/src/gpu/gpu_unai/gpu_raster_line.h
@@ -26,7 +26,9 @@
 #define GPU_DIGITS  16
 #define GPU_DIGITSC (GPU_DIGITS+3)
 
-INLINE long GPU_DIV(long rs, long rt)
+//senquack - 64-bit fix from Notaz:
+//INLINE long GPU_DIV(long rs, long rt)
+INLINE s32 GPU_DIV(s32 rs, s32 rt)
 {
 	return rt ? (SDIV(rs,rt)) : (0);
 }


### PR DESCRIPTION
Fix mask bit bug causing white rectangles in Silent Hill.
Two fixes from Notaz's pcsx_rearmed fork.
Support MIPS32 CLZ instruction.