### PR TITLE
Frontend fixes

### DIFF
--- a/src/port/sdl/frontend.cpp
+++ b/src/port/sdl/frontend.cpp
@@ -160,8 +160,12 @@ do { \
 } while (0)
 
 static char *wildcards[] = {
-	"bin", "img", "mdf", "iso", "cue", "z",
-	"bz",  "znx", "pbp", "cbn", NULL
+	//senquack - we do not (yet) support these 3 PocketISO compressed formats
+	// TODO: adapt PCSX Rearmed's cdrcimg.c plugin to get these
+	//"z", "bz", "znx",
+
+	"bin", "img", "mdf", "iso", "cue",
+	"pbp", "cbn", NULL
 };
 
 static s32 check_ext(const char *name)

--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -645,11 +645,11 @@ int main (int argc, char **argv)
 	strcpy(Config.BiosDir, biosdir);
 	strcpy(Config.Bios, BIOS_FILE);
 
-	Config.Xa=1; /* 0=XA enabled, 1=XA disabled */
+	Config.Xa=0; /* 0=XA enabled, 1=XA disabled */
 	Config.Mdec=0; /* 0=Black&White Mdecs Only Disabled, 1=Black&White Mdecs Only Enabled */
 	Config.PsxAuto=1; /* 1=autodetect system (pal or ntsc) */
 	Config.PsxType=0; /* PSX_TYPE_NTSC=ntsc, PSX_TYPE_PAL=pal */
-	Config.Cdda=1; /* 0=Enable Cd audio, 1=Disable Cd audio */
+	Config.Cdda=0; /* 0=Enable Cd audio, 1=Disable Cd audio */
 	Config.HLE=1; /* 0=BIOS, 1=HLE */
 #if defined (PSXREC)
 	Config.Cpu=0; /* 0=recompiler, 1=interpreter */
@@ -769,11 +769,11 @@ int main (int argc, char **argv)
 	for (int i=1;i<argc;i++)
 	{
 		// PCSX
-		if (strcmp(argv[i],"-xa")==0) Config.Xa=0; // XA enabled
+		if (strcmp(argv[i],"-noxa")==0) Config.Xa=1; // XA audio disabled
 		if (strcmp(argv[i],"-bwmdec")==0) Config.Mdec=1; // Black & White MDEC
 		if (strcmp(argv[i],"-pal")==0) { Config.PsxAuto=0; Config.PsxType=1; } // Force PAL system
 		if (strcmp(argv[i],"-ntsc")==0) { Config.PsxAuto=0; Config.PsxType=0; } // Force NTSC system
-		if (strcmp(argv[i],"-cdda")==0) Config.Cdda=0; // CD audio enabled
+		if (strcmp(argv[i],"-nocdda")==0) Config.Cdda=1; // CD audio disabled
 		if (strcmp(argv[i],"-bios")==0) Config.HLE=0; // BIOS enabled
 		if (strcmp(argv[i],"-interpreter")==0) Config.Cpu=1; // Interpreter enabled
 		if (strcmp(argv[i],"-rcntfix")==0) Config.RCntFix=1; // Parasite Eve 2, Vandal Hearts 1/2 Fix

--- a/src/spu/spu_pcsxrearmed/README_OPTIONS_FOR_PORT_TO_PCSX4ALL_SENQUACK.txt
+++ b/src/spu/spu_pcsxrearmed/README_OPTIONS_FOR_PORT_TO_PCSX4ALL_SENQUACK.txt
@@ -1,6 +1,3 @@
-Recommended settings:
--xa -cdda -bios
-
 Until we add a -h switch to show help, I'll refer people to this
 TXT file listing the various options of the spu_pcsxrearmed SPU
 plugin I ported from PCSX ReARMed (credit goes to Notaz), which is


### PR DESCRIPTION
Enabled XA / CDDA audio by default, can be turned off with flags -noxa & -nocdda.
In frontend, don't list CD image formats we don't support yet.