### PR TITLE
Pbp eboot work

### DIFF
--- a/src/cdriso.h
+++ b/src/cdriso.h
@@ -24,6 +24,8 @@
 void cdrIsoInit(void);
 int cdrIsoActive(void);
 
+//senquack - See note in cdriso.cpp:
+extern void (CALLBACK *cdrIsoMultidiskCallback)(void);
 extern unsigned int cdrIsoMultidiskCount;
 extern unsigned int cdrIsoMultidiskSelect;
 

--- a/src/port/sdl/frontend.cpp
+++ b/src/port/sdl/frontend.cpp
@@ -11,6 +11,7 @@
 #include "r3000a.h"
 #include "plugins.h"
 #include "cdrom.h"
+#include "cdriso.h"
 #include "profiler.h"
 #include <SDL.h>
 
@@ -472,20 +473,130 @@ static int gui_state_save()
 
 	return 1;
 }
-static int gui_swap_cd(void)
-{
-	static char isoname[PATH_MAX];
-	const char *name = FileReq(NULL, NULL, isoname);
 
-	if (name == NULL)
+//To choose which of a multi-CD image should be used. Can be called
+// from front-end 'Swap CD' menu item, in which case parameter
+// 'swapping_cd' is true. Or, can be called via callback function
+// gui_select_multicd_to_boot_from() inside cdriso.cpp, in which
+// case swapping_cd parameter is false.
+static int gui_select_multicd(bool swapping_cd)
+{
+	if (cdrIsoMultidiskCount <= 1)
 		return 0;
 
-	printf("CD swap selected file: %s\n", name);
+	// Only max of 8 ISO images inside an Eboot multi-disk .pbp are supported
+	//  by cdriso.cpp PBP code, but enforce it here to be sure:
+	int num_rows = (cdrIsoMultidiskCount > 8) ? 8 : cdrIsoMultidiskCount;
+
+	int cursor_pos = cdrIsoMultidiskSelect;
+	if ((cursor_pos >= num_rows) || (cursor_pos < 0))
+		cursor_pos = 0;
+
+	for (;;) {
+		video_clear();
+		u32 keys = key_read();
+
+		if ((swapping_cd) && (keys & KEY_SELECT)) {
+			key_reset();
+			return 0;
+		}
+
+		if (!swapping_cd)
+			port_printf(MENU_X, MENU_Y, "Multi-CD image detected:");
+
+		char tmp_string[41];
+		for (int row=0; row < num_rows; ++row) {
+			if (row == cursor_pos) {
+				// draw cursor
+				port_printf(MENU_X + 16, MENU_LS + 10 + (10 * row), "-->");
+			}
+
+			sprintf(tmp_string, "CD %d", (row+1));
+
+			if (swapping_cd && (row == cdrIsoMultidiskSelect)) {
+				// print indication of which CD is already inserted
+				strcat(tmp_string, " (inserted)");
+			}
+
+			port_printf(MENU_X + (8 * 5), MENU_LS + 10 + (10 * row), tmp_string);
+		}
+
+		if (keys & KEY_DOWN) { //down
+			if (++cursor_pos >= num_rows)
+				cursor_pos = 0;
+		} else if (keys & KEY_UP) { // up
+			if (--cursor_pos < 0)
+				cursor_pos = num_rows - 1;
+		} else if (keys & KEY_LEFT) { //left
+			cursor_pos = 0;
+		} else if (keys & KEY_RIGHT) { //right
+			cursor_pos = num_rows - 1;
+		} else if (keys & KEY_A) { // button 1
+			key_reset();
+			cdrIsoMultidiskSelect = cursor_pos;
+			video_clear();
+			video_flip();
+			return 1;
+		}
+
+		video_flip();
+		timer_delay(75);
+
+		if (keys & (KEY_A | KEY_B | KEY_X | KEY_Y | KEY_L | KEY_R |
+			    KEY_LEFT | KEY_RIGHT | KEY_UP | KEY_DOWN))
+			timer_delay(50);
+	}
+
+}
+
+//Called via callback when handlepbp() in cdriso.cpp detects a multi-CD
+// .pbp image is being loaded, so user can choose CD to boot from.
+// This is necessary because we do not know if a given CD image is
+// a multi-CD image until after cdrom plugin has gone through many
+// steps and verifications.
+static CALLBACK void gui_select_multicd_to_boot_from(void)
+{
+	if (cdrIsoMultidiskSelect >= cdrIsoMultidiskCount)
+		cdrIsoMultidiskSelect = 0;
+
+	//Pass false to indicate a CD is not being swapped through front-end menu
+	gui_select_multicd(false);
+
+	//Before return to emu, clear/flip once more in case we're triple-buffered
+	video_clear();
+	video_flip();
+}
+
+static int gui_swap_cd(void)
+{
+	//Is a multi-cd image loaded? (EBOOT .pbp files support this)
+	bool using_multicd = cdrIsoMultidiskCount > 1;
+
+	if (using_multicd) {
+		// Pass true to gui_select_multicd() so it knows CD is being swapped
+		if (!gui_select_multicd(true)) {
+			// User cancelled, return to menu
+			return 0;
+		} else {
+			printf("CD swap selected image %d of %d in multi-CD\n", cdrIsoMultidiskSelect+1, cdrIsoMultidiskCount);
+		}
+	} else {
+		static char isoname[PATH_MAX];
+		const char *name = FileReq(NULL, NULL, isoname);
+		if (name == NULL)
+			return 0;
+
+		SetIsoFile(name);
+		printf("CD swap selected file: %s\n", name);
+	}
 
 	CdromId[0] = '\0';
 	CdromLabel[0] = '\0';
 
-	SetIsoFile(name);
+	//Unregister multi-CD callback so handlepbp() or other cdriso
+	// plugins don't ask for CD to boot from
+	cdrIsoMultidiskCallback = NULL;
+
 	if (ReloadCdromPlugin() < 0) {
 		printf("Failed to re-initialize cdr\n");
 		return 0;
@@ -840,6 +951,11 @@ static int gui_LoadIso()
 
 	if (name) {
 		SetIsoFile(name);
+
+		//If a multi-CD Eboot .pbp is detected, cdriso.cpp's handlepbp() will
+		// call this function later to allow choosing which CD to boot
+		cdrIsoMultidiskCallback = gui_select_multicd_to_boot_from;
+
 		return 1;
 	}
 

--- a/src/port/sdl/frontend.cpp
+++ b/src/port/sdl/frontend.cpp
@@ -562,9 +562,7 @@ static CALLBACK void gui_select_multicd_to_boot_from(void)
 	//Pass false to indicate a CD is not being swapped through front-end menu
 	gui_select_multicd(false);
 
-	//Before return to emu, clear/flip once more in case we're triple-buffered
-	video_clear();
-	video_flip();
+	video_clear_all_backbuffers();
 }
 
 static int gui_swap_cd(void)
@@ -1071,10 +1069,14 @@ static int gui_RunMenu(MENU *menu)
 /* 0 - exit, 1 - game loaded */
 int SelectGame()
 {
-	return gui_RunMenu(&gui_MainMenu);
+	int retval = gui_RunMenu(&gui_MainMenu);
+	video_clear_all_backbuffers();
+	return retval;
 }
 
 int GameMenu()
 {
-	return gui_RunMenu(&gui_GameMenu);
+	int retval = gui_RunMenu(&gui_GameMenu);
+	video_clear_all_backbuffers();
+	return retval;
 }

--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -664,6 +664,21 @@ void video_clear(void)
 	memset(screen->pixels, 0, screen->pitch*screen->h);
 }
 
+// Used when leaving frontend GUI and going to emu:
+void video_clear_all_backbuffers(void)
+{
+	//Clear/flip twice in case we're double-buffered:
+	video_clear(); video_flip();
+	video_clear(); video_flip();
+
+#ifdef SDL_TRIPLEBUF
+	//Delay 1 frame and do again so we clear the third buffer held by last vsync:
+	SDL_Delay(17);
+	video_clear(); video_flip();
+	video_clear(); //No need to flip fourth time
+#endif
+}
+
 int main (int argc, char **argv)
 {
 	char filename[256];

--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -71,6 +71,7 @@ unsigned iocycle_ok=0;
 #endif
 
 static bool pcsx4all_initted = false;
+static bool emu_running = false;
 
 void config_load();
 void config_save();
@@ -453,7 +454,9 @@ void pad_update(void)
 
 	// SELECT+START for menu
 	if (keys[SDLK_ESCAPE] && keys[SDLK_RETURN] && !keys[SDLK_LALT]) {
+		emu_running = false;
 		GameMenu();
+		emu_running = true;
 		pad1 |= (1 << DKEY_START);
 		pad1 |= (1 << DKEY_CROSS);
 		video_clear();
@@ -623,11 +626,11 @@ void sound_set(unsigned char *pSound, long lBytes)
 void video_flip(void)
 {
 #ifdef gpu_unai
-	if (show_fps)
+	if (emu_running && show_fps)
 		port_printf(5,5,msg);
 #endif
 #ifdef gpu_dfxvideo
-	if (dfx_show_fps) {
+	if (emu_running && dfx_show_fps) {
 		char msg[256];
 		sprintf(msg, "FPS: %02.02f", fps_cur);
 		port_printf(5,5,msg);
@@ -1008,6 +1011,8 @@ int main (int argc, char **argv)
 	SCREEN = (Uint16 *)screen->pixels;
 
 	if (argc < 2 || cdrfilename[0] == '\0') {
+		// Enter frontend main-menu:
+		emu_running = false;
 		if (!SelectGame()) {
 			printf("ERROR: missing filename for -iso\n");
 			pcsx4all_exit();
@@ -1025,6 +1030,7 @@ int main (int argc, char **argv)
 	}
 
 	pcsx4all_initted = true;
+	emu_running = true;
 
 	psxReset();
 

--- a/src/port/sdl/port.h
+++ b/src/port/sdl/port.h
@@ -33,6 +33,7 @@ extern void sound_set(unsigned char *pSound, long lBytes);
 extern void video_flip(void);
 extern void video_set(unsigned short* pVideo,unsigned int width,unsigned int height);
 extern void video_clear(void);
+extern void video_clear_all_backbuffers(void);
 extern void pcsx4all_exit(void);
 extern void port_printf(int x, int y, const char *text);
 extern void port_sync(void);


### PR DESCRIPTION
* Frontend supports both swapping-to and booting-from any CD in multi-CD Eboot images.

* Frontend now clears all backbuffers before returning to emu, fixing occaisional flicker of old menu contents on emu's screen when game doesn't isn't using full screen res.

* Don't show FPS stats when menu is active.