### PR TITLE
Rootcounter work

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -406,10 +406,6 @@ int CheckCdrom() {
 		if (CdromId[2] == 'e' || CdromId[2] == 'E')
 			Config.PsxType = PSX_TYPE_PAL; // pal
 		else Config.PsxType = PSX_TYPE_NTSC; // ntsc
-
-		//senquack - This was carried over from older PCSX4ALL code during
-		// update of this function to use PCSX Rearmed code
-		psxRcntUVtarget();
 	}
 
 	if (CdromLabel[0] == ' ') {

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -134,8 +134,8 @@ extern void SPU_playCDDAchannel(unsigned char *, int);
 extern "C" {
 #endif
 
-void CALLBACK AcknowledgeSPUIRQ();
-void CALLBACK ScheduleSPUUpdate(unsigned int cycles_after);
+void CALLBACK Trigger_SPU_IRQ(void);
+void CALLBACK Schedule_SPU_IRQ(unsigned int cycles_after);
 
 #ifdef __cplusplus
 }

--- a/src/psxbios.cpp
+++ b/src/psxbios.cpp
@@ -1354,6 +1354,7 @@ void psxBios_LoadExec(void) { // 51
 	psxBios_Exec();
 }
 
+//senquack - updated to match PCSX Rearmed:
 void psxBios__bu_init(void) { // 70
 #ifdef PSXBIOS_LOG
 	PSXBIOS_LOG("psxBios_%s\n", biosA0n[0x70]);
@@ -1365,12 +1366,6 @@ void psxBios__bu_init(void) { // 70
 	pc0 = ra;
 	if (autobias)
 		psxRegs.cycle+=8192;
-	while(psxGetHSync()){
-		u32 c=rcnts[3].cycle + rcnts[3].cycleStart;
-		if (psxRegs.cycle<c)
-			psxRegs.cycle=c+1;
-		psxRcntUpdate();
-	}
 }
 
 void psxBios__96_init(void) { // 71

--- a/src/psxcounters.h
+++ b/src/psxcounters.h
@@ -27,6 +27,7 @@
 #include "plugins.h"
 
 extern u32 psxNextCounter, psxNextsCounter;
+extern u32 spu_upd_interval;
 
 typedef struct Rcnt
 {
@@ -34,9 +35,6 @@ typedef struct Rcnt
     u32 rate, irq, counterState, irqState;
     u32 cycle, cycleStart;
 } Rcnt;
-extern Rcnt rcnts[];
-
-extern void psxRcntUVtarget(void);
 
 extern void psxRcntInit(void);
 extern void psxRcntUpdate(void);
@@ -51,8 +49,6 @@ extern u32 psxRcntRtarget(u32 index);
 
 extern s32 psxRcntFreeze(gzFile f, s32 Mode);
 
-extern void psxSetSyncs(unsigned h_sync, unsigned s_sync);
-extern unsigned psxGetHSync(void);
 extern unsigned psxGetSpuSync(void);
 
 #endif /* __PSXCOUNTERS_H__ */

--- a/src/r3000a.h
+++ b/src/r3000a.h
@@ -154,12 +154,19 @@ enum {
 	PSXINT_GPUOTCDMA,
 	PSXINT_CDRDMA,
 	PSXINT_NEWDRC_CHECK,
-	PSXINT_RCNT,
+	PSXINT_RCNT,          //senquack - not used (see psxcounters.cpp)
 	PSXINT_CDRLID,
 	PSXINT_CDRPLAY,
-	PSXINT_SPU_UPDATE,
+	PSXINT_SPUIRQ,
 	PSXINT_COUNT
 };
+
+// senquack- TODO: add ResetIoCycle() like other older PCSX4ALL code has
+//  littered everywhere?
+#define SCHEDULE_SPU_UPDATE(eCycle) { \
+	psxRegs.SPU_intCycle.cycle = eCycle; \
+	psxRegs.SPU_intCycle.sCycle = psxRegs.cycle; \
+}
 
 typedef struct {
 	psxGPRRegs GPR;		/* General Purpose Registers */
@@ -174,6 +181,9 @@ typedef struct {
 	//senquack - Converted to newer PCSXR struct:
 	//u32 intCycle[32];
 	struct { u32 sCycle, cycle; } intCycle[32];
+
+	// SPU update handled separately since it is persistent:
+	struct { u32 sCycle, cycle; } SPU_intCycle;
 
 // CHUI: Añado los ciclos hasta el proximo evento.
 	u32 io_cycle_counter;

--- a/src/sio.cpp
+++ b/src/sio.cpp
@@ -74,7 +74,12 @@ void sioInit(void) {
 	if (autobias)
 		sio_cycle=136*8;
 	else
-		sio_cycle=200*BIAS; /* for SIO_INT() */
+		//senquack-Rearmed uses 535 in all cases, so we'll use that instead:
+		//sio_cycle=200*BIAS; /* for SIO_INT() */
+
+		// clk cycle byte
+		// 4us * 8bits = (PSXCLK / 1000000) * 32; (linuzappz)
+		sio_cycle=535;
 }
 
 //senquack - Updated to use PSXINT_* enum and intCycle struct (much cleaner than before)
@@ -294,7 +299,8 @@ void sioWriteCtrl16(unsigned short value) {
 #endif
 	CtrlReg = value & ~RESET_ERR;
 	if (value & RESET_ERR) StatReg &= ~IRQ;
-	//senquack - Updated to match PCSXR:
+	//senquack - Updated to match PCSX Rearmed
+	// 'no DTR resets device, tested on the real thing'
 	//if ((CtrlReg & SIO_RESET) || (!CtrlReg)) {
 	if ((CtrlReg & SIO_RESET) || !(CtrlReg & DTR)) {
 		padst = 0; mcdst = 0; parp = 0;

--- a/src/sio.cpp
+++ b/src/sio.cpp
@@ -387,10 +387,13 @@ void sioInterrupt() {
 #ifdef PAD_LOG
 	PAD_LOG("Sio Interrupt (CP0.Status = %x)\n", psxRegs.CP0.n.Status);
 #endif
-//	printf("Sio Interrupt\n");
-	StatReg|= IRQ;
-	psxHu32ref(0x1070)|= SWAPu32(0x80);
-// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
+	//printf("Sio Interrupt\n");
+	//  pcsx_rearmed: only do IRQ if it's bit has been cleared
+	if (!(StatReg & IRQ)) {
+		StatReg |= IRQ;
+		psxHu32ref(0x1070) |= SWAPu32(0x80);
+	}
+	// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
 	ResetIoCycle();
 }
 

--- a/src/spu/spu_pcsxrearmed/spu.c
+++ b/src/spu/spu_pcsxrearmed/spu.c
@@ -1601,26 +1601,29 @@ void CALLBACK SPUabout(void)
 }
 
 // SETUP CALLBACKS
-// this functions will be called once, 
-// passes a callback that should be called on SPU-IRQ/cdda volume change
+
 //senquack - NOTE: this is an important function to register, as SPU
-// IRQs will not be acknowledged otherwise, leading to repeating/missing sfx
-// problems in games like NFS3, Grandia, Fifa98, Chrono Cross, etc. Implemented
-// in PCSX4ALL via new function AcknowledgeSPUIRQ() in plugins.cpp.
+// IRQs will not be handled otherwise, leading to repeating/missing sfx
+// problems in games like NFS3, Grandia, Fifa98, Chrono Cross, etc.
+// Implemented in PCSX4ALL via new function Trigger_SPU_IRQ() in plugins.cpp.
 void CALLBACK SPUregisterCallback(void (CALLBACK *callback)(void))
 {
  spu.irqCallback = callback;
 }
 
+// Callback to schedule a scan for upcoming SPU HW IRQs, calling
+//  above callback as needed.
+void CALLBACK SPUregisterScheduleCb(void (CALLBACK *callback)(unsigned int))
+{
+ spu.scheduleCallback = callback;
+}
+
+// A callback that should be called on SPU-IRQ/cdda volume change
 void CALLBACK SPUregisterCDDAVolume(void (CALLBACK *CDDAVcallback)(unsigned short,unsigned short))
 {
  spu.cddavCallback = CDDAVcallback;
 }
 
-void CALLBACK SPUregisterScheduleCb(void (CALLBACK *callback)(unsigned int))
-{
- spu.scheduleCallback = callback;
-}
 
 // COMMON PLUGIN INFO FUNCS
 /*

--- a/src/spu/spu_pcsxrearmed/spu_pcsxrearmed_wrapper.h
+++ b/src/spu/spu_pcsxrearmed/spu_pcsxrearmed_wrapper.h
@@ -159,14 +159,13 @@ static inline int SPU_playCDDAchannel(short *pcm, int bytes)
     return SPUplayCDDAchannel(pcm, bytes);
 }
 
-//senquack - IRQ callback (implemented via AcknowledgeSPUIRQ() in PCSX4ALL plugins.cpp)
+//senquack - SPU IRQ callback
 static inline void SPU_registerCallback(void (CALLBACK *callback)(void))
 {
 	SPUregisterCallback(callback);
 }
 
-//senquack - Schedule SPU update callback (implemented via ScheduleSPUUpdate()
-// in PCSX4ALL plugins.cpp)
+//senquack - Schedule SPU update callback (to scan for upcoming SPU IRQ)
 static inline void SPU_registerScheduleCb(void (CALLBACK *callback)(unsigned int))
 {
 	SPUregisterScheduleCb(callback);


### PR DESCRIPTION
* Use more accurate and efficient rootcounter code of PCSX Rearmed in psxcounter.cpp (Cotton and Metal Slug X input is now fixed, no surprise since gamepad updates on PS1 hardware are tied to VBlank rootcounter)

* Because VBlank rootcounter is no longer called every HSYNC, sound update is done in psxBranchTest() in r3000a.cpp

* Some modifications to SIO code based on PCSX Rearmed (SIO IRQ, sio_cycles value)

* Clarified SPU callback function names in plugins.cpp, clarified comments.

* Added audio buffer debugging statistics to spu_pcsxrearmed SDL backend.