### PR TITLE
Gpu work

### DIFF
--- a/Makefile.caanoo
+++ b/Makefile.caanoo
@@ -36,7 +36,7 @@ CFLAGS = -mcpu=arm926ej-s -mtune=arm926ej-s $(DEVLIBS) \
 	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return \
     -Isrc -Isrc/zlib -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) -D$(GPU) -D$(INTERPRETER) -D$(RECOMPILER) -D$(GTE) -Isrc/port/$(PORT) -Isrc/gte/$(GTE) \
     -DXA_HACK -DBIOS_FILE=$(BIOS_FILE) -DMCD1_FILE=$(MCD1_FILE) -DMCD2_FILE=$(MCD2_FILE) \
-    -D__arm__ -DWIZ -DMMUHACK -DINLINE="static __inline" -Dasm="__asm__ __volatile__" -Wshadow -DPSXREC
+    -D__arm__ -DWIZ -DMMUHACK -DINLINE="static __inline__" -Dasm="__asm__ __volatile__" -Wshadow -DPSXREC
 	# -fsigned-char 
 	# -Wstrict-prototypes -Wbad-function-cast
     # -Wshadow

--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -42,7 +42,7 @@ CFLAGS = -mips32r2 -ggdb3 -O2 -DGCW_ZERO \
 	-Isrc/gte/$(GTE) -D$(INTERPRETER) -D$(GTE) \
 	-DXA_HACK -DBIOS_FILE=$(BIOS_FILE) -DMCD1_FILE=$(MCD1_FILE) \
 	-DMCD2_FILE=$(MCD2_FILE) \
-	-DINLINE="static __inline" -Dasm="__asm__ __volatile__" \
+	-DINLINE="static __inline__" -Dasm="__asm__ __volatile__" \
 	$(SDL_CFLAGS)
 
 ifdef RECOMPILER

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -42,7 +42,7 @@ CFLAGS = -ggdb3 -O2 -march=native -DGCW_ZERO \
 	-Isrc/gte/$(GTE) -D$(INTERPRETER) -D$(GTE) \
 	-DXA_HACK -DBIOS_FILE=$(BIOS_FILE) -DMCD1_FILE=$(MCD1_FILE) \
 	-DMCD2_FILE=$(MCD2_FILE) \
-	-DINLINE="static __inline" -Dasm="__asm__ __volatile__" \
+	-DINLINE="static __inline__" -Dasm="__asm__ __volatile__" \
 	$(SDL_CFLAGS)
 
 #CFLAGS += -DDEBUG_IO_CYCLE_COUNTER

--- a/Makefile.win32
+++ b/Makefile.win32
@@ -40,7 +40,7 @@ CFLAGS = -ggdb3 -O2 -march=i686 -DGCW_ZERO \
 	-Isrc/gte/$(GTE) -D$(INTERPRETER) -D$(GTE) \
 	-DXA_HACK -DBIOS_FILE=$(BIOS_FILE) -DMCD1_FILE=$(MCD1_FILE) \
 	-DMCD2_FILE=$(MCD2_FILE) \
-	-DINLINE="static __inline" -Dasm="__asm__ __volatile__" \
+	-DINLINE="static __inline__" -Dasm="__asm__ __volatile__" \
 	$(SDL_CFLAGS)
 
 #CFLAGS += -DDEBUG_IO_CYCLE_COUNTER

--- a/Makefile.wiz
+++ b/Makefile.wiz
@@ -41,7 +41,7 @@ CFLAGS = -mcpu=arm926ej-s -mtune=arm926ej-s $(DEVLIBS) \
 	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return \
     -Isrc -Isrc/zlib -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) -D$(GPU) -D$(INTERPRETER) -D$(RECOMPILER) -D$(GTE) -Isrc/port/$(PORT) -Isrc/gte/$(GTE) \
     -DXA_HACK -DBIOS_FILE=$(BIOS_FILE) -DMCD1_FILE=$(MCD1_FILE) -DMCD2_FILE=$(MCD2_FILE) \
-    -D__arm__ -DWIZ -DMMUHACK -DINLINE="static __inline" -Dasm="__asm__ __volatile__" -Wshadow -DPSXREC
+    -D__arm__ -DWIZ -DMMUHACK -DINLINE="static __inline__" -Dasm="__asm__ __volatile__" -Wshadow -DPSXREC
 	# -fsigned-char 
 	# -Wstrict-prototypes -Wbad-function-cast
     # -Wshadow

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -1,0 +1,44 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Copyright (C) 2010-2013 Gražvydas "notaz" Ignotas                     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+//senquack - Added from PCSX Rearmed - More accurate emulation of GPU status register
+
+/*
+ * q: Why bother with GPU stuff in a plugin-based emu core?
+ * a: mostly because of busy bits, we have all the needed timing info
+ *    that GPU plugin doesn't.
+ */
+
+#define PSXGPU_LCF     (1<<31)
+#define PSXGPU_nBUSY   (1<<26)
+#define PSXGPU_ILACE   (1<<22)
+#define PSXGPU_DHEIGHT (1<<19)
+
+// both must be set for interlace to work
+#define PSXGPU_ILACE_BITS (PSXGPU_ILACE | PSXGPU_DHEIGHT)
+
+#define HW_GPU_STATUS psxHu32ref(0x1814)
+
+// TODO: handle com too
+#define PSXGPU_TIMING_BITS (PSXGPU_LCF | PSXGPU_nBUSY)
+
+#define gpuSyncPluginSR() { \
+	HW_GPU_STATUS &= PSXGPU_TIMING_BITS; \
+	HW_GPU_STATUS |= GPU_readStatus() & ~PSXGPU_TIMING_BITS; \
+}

--- a/src/gpu/gpu_unai/gpu.cpp
+++ b/src/gpu/gpu_unai/gpu.cpp
@@ -108,8 +108,15 @@ u32   lInc;
 u32 u4_msk, v4_msk;
 
 GPUPacket PacketBuffer;
-// FRAME_BUFFER_SIZE is defined in bytes; 512K is guard memory for out of range reads
-u16   GPU_FrameBuffer[(FRAME_BUFFER_SIZE+512*1024)/2] __attribute__((aligned(32)));
+//senquack - Original 512KB of guard space seems not to be enough, as Xenogears
+// accesses outside this range and crashes in town intro fight sequence.
+// Increased to 2MB total (double PSX VRAM) and Xenogears no longer
+// crashes, but some textures are still messed up. Also note that alignment
+// is increased to 2048 (Rearmed behavior) which should give some more guard room.
+// TODO: Determine cause of out-of-bounds write/reads.
+//u16   GPU_FrameBuffer[(FRAME_BUFFER_SIZE+512*1024)/2] __attribute__((aligned(32)));
+u16 GPU_FrameBuffer[(FRAME_BUFFER_SIZE*2)/2] __attribute__((aligned(2048)));
+
 u32   GPU_GP1;
 
 u32 tw=0; /* texture window */

--- a/src/gpu/gpu_unai/gpu.cpp
+++ b/src/gpu/gpu_unai/gpu.cpp
@@ -755,6 +755,8 @@ static void gpuVideoOutput(void)
 				}
 				break;
 			case 320:
+				//senquack - ensure 32-bit alignment for GPU_BlitWW() blitter:
+				src_screen16 = (u16*)((uintptr_t)src_screen16 & (~3));
 				for(int y1=y0+h1; y0<y1; y0+=incY)
 				{
 					if(( 0 == (y0&li) ) && ((!pi) || (pif=!pif))) GPU_BlitWW(	src_screen16,	dest_screen16, isRGB24);

--- a/src/gpu/gpu_unai/gpu_command.h
+++ b/src/gpu/gpu_unai/gpu_command.h
@@ -319,7 +319,16 @@ void gpuSendPacketFunction(const int PRIM)
 				NULL_GPU();
 				gpuSetCLUT    (PacketBuffer.U4[2] >> 16);
 				gpuSetTexture (GPU_GP1);
-				if ((PacketBuffer.U1[0]>0x5F) && (PacketBuffer.U1[1]>0x5F) && (PacketBuffer.U1[2]>0x5F))
+				//senquack - Only color 808080h allows skipping lighting calculation:
+				// This fixes Silent Hill running animation on loading screens:
+				// (Color values 0x00-0x7F darken the source texture's color,
+				//  0x81-FF lighten textures (ultimately clamped to 0x1F),
+				//  0x80 leaves source texture color unchanged.
+				// NOTE: I've changed all textured sprite draw commands here and
+				//  elsewhere to use proper behavior, but left poly commands
+				//  alone, I don't want to slow rendering down too much. (TODO)
+				//if ((PacketBuffer.U1[0]>0x5F) && (PacketBuffer.U1[1]>0x5F) && (PacketBuffer.U1[2]>0x5F))
+				if ((PacketBuffer.U4[0] & 0xFFFFFF) == 0x808080)
 					gpuDrawS(gpuSpriteSpanDrivers [Blending_Mode | TEXT_MODE | Masking | Blending | (PixelMSB>>1)]);
 				else
 					gpuDrawS(gpuSpriteSpanDrivers [Blending_Mode | TEXT_MODE | Masking | Blending | Lighting | (PixelMSB>>1)]);
@@ -363,7 +372,9 @@ void gpuSendPacketFunction(const int PRIM)
 				PacketBuffer.U4[3] = 0x00080008;
 				gpuSetCLUT    (PacketBuffer.U4[2] >> 16);
 				gpuSetTexture (GPU_GP1);
-				if ((PacketBuffer.U1[0]>0x5F) && (PacketBuffer.U1[1]>0x5F) && (PacketBuffer.U1[2]>0x5F))
+				//senquack - Only color 808080h allows skipping lighting calculation:
+				//if ((PacketBuffer.U1[0]>0x5F) && (PacketBuffer.U1[1]>0x5F) && (PacketBuffer.U1[2]>0x5F))
+				if ((PacketBuffer.U4[0] & 0xFFFFFF) == 0x808080)
 					gpuDrawS(gpuSpriteSpanDrivers [Blending_Mode | TEXT_MODE | Masking | Blending | (PixelMSB>>1)]);
 				else
 					gpuDrawS(gpuSpriteSpanDrivers [Blending_Mode | TEXT_MODE | Masking | Blending | Lighting | (PixelMSB>>1)]);
@@ -405,7 +416,9 @@ void gpuSendPacketFunction(const int PRIM)
 				PacketBuffer.U4[3] = 0x00100010;
 				gpuSetCLUT    (PacketBuffer.U4[2] >> 16);
 				gpuSetTexture (GPU_GP1);
-				if ((PacketBuffer.U1[0]>0x5F) && (PacketBuffer.U1[1]>0x5F) && (PacketBuffer.U1[2]>0x5F))
+				//senquack - Only color 808080h allows skipping lighting calculation:
+				//if ((PacketBuffer.U1[0]>0x5F) && (PacketBuffer.U1[1]>0x5F) && (PacketBuffer.U1[2]>0x5F))
+				if ((PacketBuffer.U4[0] & 0xFFFFFF) == 0x808080)
 					gpuDrawS(gpuSpriteSpanDrivers [Blending_Mode | TEXT_MODE | Masking | Blending | (PixelMSB>>1)]);
 				else
 					gpuDrawS(gpuSpriteSpanDrivers [Blending_Mode | TEXT_MODE | Masking | Blending | Lighting | (PixelMSB>>1)]);

--- a/src/gpu/gpu_unai/gpu_inner.h
+++ b/src/gpu/gpu_unai/gpu_inner.h
@@ -51,7 +51,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 //  GPU Pixel operations generator
 template<const int CF>
-INLINE void gpuPixelFn(u16 *pixel,const u16 data)
+static void gpuPixelFn(u16 *pixel,const u16 data)
 {
 	if ((!M)&&(!B))
 	{
@@ -82,7 +82,7 @@ INLINE void gpuPixelFn(u16 *pixel,const u16 data)
 	}
 }
 
-INLINE void PixelNULL(u16 *pixel,const u16 data)
+static void PixelNULL(u16 *pixel,const u16 data)
 {
 	#ifdef ENABLE_GPU_LOG_SUPPORT
 		fprintf(stdout,"PixelNULL()\n");
@@ -111,7 +111,7 @@ const PD  gpuPixelDrivers[32] =   //  We only generate pixel op for MASKING/BLEN
 //  GPU Tiles innerloops generator
 
 template<const int CF>
-INLINE void  gpuTileSpanFn(u16 *pDst, u32 count, u16 data)
+static void gpuTileSpanFn(u16 *pDst, u32 count, u16 data)
 {
 	if ((!M)&&(!B))
 	{
@@ -156,7 +156,7 @@ INLINE void  gpuTileSpanFn(u16 *pDst, u32 count, u16 data)
 	}
 }
 
-INLINE void TileNULL(u16 *pDst, u32 count, u16 data)
+static void TileNULL(u16 *pDst, u32 count, u16 data)
 {
 	#ifdef ENABLE_GPU_LOG_SUPPORT
 		fprintf(stdout,"TileNULL()\n");
@@ -179,7 +179,7 @@ const PT gpuTileSpanDrivers[64] =
 //  GPU Sprites innerloops generator
 
 template<const int CF>
-INLINE void  gpuSpriteSpanFn(u16 *pDst, u32 count, u32 u0, const u32 mask)
+static void  gpuSpriteSpanFn(u16 *pDst, u32 count, u32 u0, const u32 mask)
 {
 	u16 uSrc;
 	u16 uDst;
@@ -249,7 +249,7 @@ INLINE void  gpuSpriteSpanFn(u16 *pDst, u32 count, u32 u0, const u32 mask)
 	while (--count);
 }
 
-INLINE void SpriteNULL(u16 *pDst, u32 count, u32 u0, const u32 mask)
+static void SpriteNULL(u16 *pDst, u32 count, u32 u0, const u32 mask)
 {
 	#ifdef ENABLE_GPU_LOG_SUPPORT
 		fprintf(stdout,"SpriteNULL()\n");
@@ -301,7 +301,7 @@ const PS gpuSpriteSpanDrivers[256] =
 //             across calls to blending functions (Silent Hill rectangles fix)
 // (see README_senquack.txt)
 template<const int CF>
-void gpuPolySpanFn(u16 *pDst, u32 count)
+static void gpuPolySpanFn(u16 *pDst, u32 count)
 {
 	if (!TM)
 	{	
@@ -510,7 +510,7 @@ void gpuPolySpanFn(u16 *pDst, u32 count)
 	}
 }
 
-INLINE void PolyNULL(u16 *pDst, u32 count)
+static void PolyNULL(u16 *pDst, u32 count)
 {
 	#ifdef ENABLE_GPU_LOG_SUPPORT
 		fprintf(stdout,"PolyNULL()\n");

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -28,6 +28,7 @@
 #include "misc.h"
 #include "cdrom.h"
 #include "mdec.h"
+#include "gpu.h"
 #include "ppf.h"
 #include "port.h"
 
@@ -583,6 +584,8 @@ int SaveState(const char *file) {
     if(!GPU_freeze(1, gpufP)) return -3;
     FWRITE(f, gpufP, sizeof(GPUFreeze_t));
 	free(gpufP);
+	if (HW_GPU_STATUS == 0)
+		HW_GPU_STATUS = GPU_readStatus();
 
 	// spu
 	spufP = (SPUFreeze_t *) malloc(16);

--- a/src/psxbios.cpp
+++ b/src/psxbios.cpp
@@ -24,6 +24,7 @@
 
 #include "psxbios.h"
 #include "psxhw.h"
+#include "gpu.h"
 #include "profiler.h"
 
 //We try to emulate bios :) HELP US :P
@@ -1275,6 +1276,7 @@ void psxBios_mem2vram(void) { // 0x47
 
 void psxBios_SendGPU(void) { // 0x48
 	GPU_writeStatus(a0);
+	gpuSyncPluginSR();
 	pc0 = ra;
 }
 

--- a/src/psxcounters.h
+++ b/src/psxcounters.h
@@ -1,4 +1,5 @@
 /***************************************************************************
+ *   Copyright (C) 2010 by Blade_Arma                                      *
  *   Copyright (C) 2007 Ryan Schultz, PCSX-df Team, PCSX team              *
  *   schultz.ryan@gmail.com, http://rschultz.ath.cx/code.php               *
  *                                                                         *
@@ -27,6 +28,7 @@
 #include "plugins.h"
 
 extern u32 psxNextCounter, psxNextsCounter;
+extern u32 hSyncCount, frame_counter;
 extern u32 spu_upd_interval;
 
 typedef struct Rcnt

--- a/src/psxdma.cpp
+++ b/src/psxdma.cpp
@@ -23,6 +23,7 @@
 */
 
 #include "psxdma.h"
+#include "gpu.h"
 
 // Dma0/1 in Mdec.c
 // Dma3   in CdRom.c
@@ -151,6 +152,7 @@ static u32 gpuDmaChainSize(u32 addr) {
 	return size;
 }
 
+//senquack - updated to match PCSX Rearmed:
 void psxDma2(u32 madr, u32 bcr, u32 chcr) { // GPU
 #ifdef DEBUG_ANALYSIS
 	dbg_anacnt_psxDma2++;
@@ -212,8 +214,7 @@ void psxDma2(u32 madr, u32 bcr, u32 chcr) { // GPU
 			size = GPU_dmaChain((u32 *)psxM, madr & 0x1fffff);
 			if ((int)size <= 0)
 				size = gpuDmaChainSize(madr);
-			
-			//senquack - TODO: add HW_GPU_STATUS from PCSX Rearmed
+			HW_GPU_STATUS &= ~PSXGPU_nBUSY;
 
 			// we don't emulate progress, just busy flag and end irq,
 			// so pretend we're already at the last block
@@ -239,6 +240,7 @@ void psxDma2(u32 madr, u32 bcr, u32 chcr) { // GPU
 	DMA_INTERRUPT(2);
 }
 
+//senquack - updated to match PCSX Rearmed:
 void gpuInterrupt() {
 #ifdef DEBUG_ANALYSIS
 	dbg_anacnt_gpuInterrupt++;
@@ -248,8 +250,7 @@ void gpuInterrupt() {
 		HW_DMA2_CHCR &= SWAP32(~0x01000000);
 		DMA_INTERRUPT(2);
 	}
-	
-	//senquack - TODO: implement HW_GPU_STATUS from Rearmed here
+	HW_GPU_STATUS |= PSXGPU_nBUSY; // GPU no longer busy
 }
 
 void psxDma6(u32 madr, u32 bcr, u32 chcr) {

--- a/src/psxdma.cpp
+++ b/src/psxdma.cpp
@@ -156,6 +156,7 @@ void psxDma2(u32 madr, u32 bcr, u32 chcr) { // GPU
 	dbg_anacnt_psxDma2++;
 #endif
 	u32 *ptr;
+	u32 words;
 	u32 size;
 
 	switch(chcr) {
@@ -164,21 +165,44 @@ void psxDma2(u32 madr, u32 bcr, u32 chcr) { // GPU
 			PSXDMA_LOG("*** DMA2 GPU - vram2mem *** %x addr = %x size = %x\n", chcr, madr, bcr);
 #endif
 			ptr = (u32 *)PSXM(madr);
-			size = (bcr >> 16) * (bcr & 0xffff);
-			GPU_readDataMem(ptr, size);
+			if (ptr == NULL) {
+#ifdef CPU_LOG
+				CPU_LOG("*** DMA2 GPU - vram2mem *** NULL Pointer!!!\n");
+#endif
+				break;
+			}
+			// BA blocks * BS words (word = 32-bits)
+			words = (bcr >> 16) * (bcr & 0xffff);
+			GPU_readDataMem(ptr, words);
 			#ifdef PSXREC
-			psxCpu->Clear(madr, size);
+			psxCpu->Clear(madr, words);
 			#endif
-			break;
+
+			HW_DMA2_MADR = SWAPu32(madr + words * 4);
+
+			// already 32-bit word size ((size * 4) / 4)
+			GPUDMA_INT(words / 4);
+			return;
 
 		case 0x01000201: // mem2vram
 #ifdef PSXDMA_LOG
 			PSXDMA_LOG("*** DMA 2 - GPU mem2vram *** %x addr = %x size = %x\n", chcr, madr, bcr);
 #endif
 			ptr = (u32 *)PSXM(madr);
-			size = (bcr >> 16) * (bcr & 0xffff);
-			GPU_writeDataMem(ptr, size);
-			GPUDMA_INT(size / 4);
+			if (ptr == NULL) {
+#ifdef CPU_LOG
+				CPU_LOG("*** DMA2 GPU - mem2vram *** NULL Pointer!!!\n");
+#endif
+				break;
+			}
+			// BA blocks * BS words (word = 32-bits)
+			words = (bcr >> 16) * (bcr & 0xffff);
+			GPU_writeDataMem(ptr, words);
+
+			HW_DMA2_MADR = SWAPu32(madr + words * 4);
+
+			// already 32-bit word size ((size * 4) / 4)
+			GPUDMA_INT(words / 4);
 			return;
 
 		case 0x01000401: // dma chain
@@ -189,6 +213,12 @@ void psxDma2(u32 madr, u32 bcr, u32 chcr) { // GPU
 			if ((int)size <= 0)
 				size = gpuDmaChainSize(madr);
 			
+			//senquack - TODO: add HW_GPU_STATUS from PCSX Rearmed
+
+			// we don't emulate progress, just busy flag and end irq,
+			// so pretend we're already at the last block
+			HW_DMA2_MADR = SWAPu32(0xffffff);
+
 			// Tekken 3 = use 1.0 only (not 1.5x)
 
 			// Einhander = parse linked list in pieces (todo)
@@ -221,6 +251,7 @@ void psxDma6(u32 madr, u32 bcr, u32 chcr) {
 #ifdef DEBUG_ANALYSIS
 	dbg_anacnt_psxDma6++;
 #endif
+	u32 words;
 	u32 *mem = (u32 *)PSXM(madr);
 
 #ifdef PSXDMA_LOG
@@ -228,11 +259,29 @@ void psxDma6(u32 madr, u32 bcr, u32 chcr) {
 #endif
 
 	if (chcr == 0x11000002) {
+		if (mem == NULL) {
+#ifdef CPU_LOG
+			CPU_LOG("*** DMA6 OT *** NULL Pointer!!!\n");
+#endif
+			HW_DMA6_CHCR &= SWAP32(~0x01000000);
+			DMA_INTERRUPT(6);
+			return;
+		}
+
+		// already 32-bit size
+		words = bcr;
+
 		while (bcr--) {
 			*mem-- = SWAP32((madr - 4) & 0xffffff);
 			madr -= 4;
 		}
 		mem++; *mem = 0xffffff;
+
+		//GPUOTCDMA_INT(size);
+		// halted
+		psxRegs.cycle += words;
+		GPUOTCDMA_INT(16);
+		return;
 	}
 #ifdef PSXDMA_LOG
 	else {
@@ -245,3 +294,12 @@ void psxDma6(u32 madr, u32 bcr, u32 chcr) {
 	DMA_INTERRUPT(6);
 }
 
+//senquack - New from PCSX Rearmed:
+void gpuotcInterrupt()
+{
+	if (HW_DMA6_CHCR & SWAP32(0x01000000))
+	{
+		HW_DMA6_CHCR &= SWAP32(~0x01000000);
+		DMA_INTERRUPT(6);
+	}
+}

--- a/src/psxdma.cpp
+++ b/src/psxdma.cpp
@@ -243,8 +243,13 @@ void gpuInterrupt() {
 #ifdef DEBUG_ANALYSIS
 	dbg_anacnt_gpuInterrupt++;
 #endif
-	HW_DMA2_CHCR &= SWAP32(~0x01000000);
-	DMA_INTERRUPT(2);
+	if (HW_DMA2_CHCR & SWAP32(0x01000000))
+	{
+		HW_DMA2_CHCR &= SWAP32(~0x01000000);
+		DMA_INTERRUPT(2);
+	}
+	
+	//senquack - TODO: implement HW_GPU_STATUS from Rearmed here
 }
 
 void psxDma6(u32 madr, u32 bcr, u32 chcr) {

--- a/src/psxdma.h
+++ b/src/psxdma.h
@@ -72,11 +72,12 @@
 	psxRegs.intCycle[PSXINT_CDRDMA].sCycle = psxRegs.cycle; \
 }
 
-extern void psxDma2(u32 madr, u32 bcr, u32 chcr);
-extern void psxDma3(u32 madr, u32 bcr, u32 chcr);
-extern void psxDma4(u32 madr, u32 bcr, u32 chcr);
-extern void psxDma6(u32 madr, u32 bcr, u32 chcr);
-extern void gpuInterrupt(void);
-extern void spuInterrupt(void);
+void psxDma2(u32 madr, u32 bcr, u32 chcr);
+void psxDma3(u32 madr, u32 bcr, u32 chcr);
+void psxDma4(u32 madr, u32 bcr, u32 chcr);
+void psxDma6(u32 madr, u32 bcr, u32 chcr);
+void gpuInterrupt(void);
+void spuInterrupt(void);
+void gpuotcInterrupt();
 
 #endif /* __PSXDMA_H__ */

--- a/src/r3000a.cpp
+++ b/src/r3000a.cpp
@@ -52,7 +52,7 @@ const u32 * const psxRegs_cycle_valptr = &psxRegs.cycle;
 int psxInit() {
 	printf("Running PCSX Version %s (%s).\n", PACKAGE_VERSION, __DATE__);
 
-// CHUI: Añado el inicio del profiler
+// CHUI: AÃ±ado el inicio del profiler
 	pcsx4all_prof_init();
 	pcsx4all_prof_add("CPU"); // PCSX4ALL_PROF_CPU
 	pcsx4all_prof_add("HW_READ"); // PCSX4ALL_PROF_HW_READ
@@ -88,7 +88,7 @@ void psxReset() {
 	memset(&psxRegs, 0, sizeof(psxRegs));
 
 	psxRegs.pc = 0xbfc00000; // Start in bootstrap
-// CHUI: Añadimos el puntero a la memoria PSX
+// CHUI: AÃ±adimos el puntero a la memoria PSX
 	psxRegs.psxM = psxM;	// PSX Memory
 	psxRegs.psxP = psxP;	// PSX Memory
 	psxRegs.psxR = psxR;	// PSX Memory
@@ -146,7 +146,7 @@ void psxException(u32 code, u32 bd) {
 	// Set the Status
 	psxRegs.CP0.n.Status = (psxRegs.CP0.n.Status &~0x3f) |
 						  ((psxRegs.CP0.n.Status & 0xf) << 2);
-// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
+// CHUI: AÃ±ado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
 	ResetIoCycle();
 
 	if (!Config.HLE && (((PSXMu32(psxRegs.CP0.n.EPC) >> 24) & 0xfe) == 0x4a)) {
@@ -486,6 +486,12 @@ void psxBranchTest() {
 			if ((psxRegs.cycle - psxRegs.intCycle[PSXINT_MDECINDMA].sCycle) >= psxRegs.intCycle[PSXINT_MDECINDMA].cycle) {
 				psxRegs.interrupt &= ~(1 << PSXINT_MDECINDMA);
 				mdec0Interrupt();
+			}
+		}
+		if (psxRegs.interrupt & (1 << PSXINT_GPUOTCDMA)) { // gpu otc
+			if ((psxRegs.cycle - psxRegs.intCycle[PSXINT_GPUOTCDMA].sCycle) >= psxRegs.intCycle[PSXINT_GPUOTCDMA].cycle) {
+				psxRegs.interrupt &= ~(1 << PSXINT_GPUOTCDMA);
+				gpuotcInterrupt();
 			}
 		}
 		if (psxRegs.interrupt & (1 << PSXINT_CDRDMA)) { // cdrom


### PR DESCRIPTION
- GPU-related DMA code updated to match Rearmed
- GPU status handling updated to match Rearmed
- gpu_unai sprite lighting corrected: Silent Hill load-screen animation now blends properly
- gpu_unai VRAM guard buffer size increased (Xenogears doesn't crash in intro anymore)
- gpu_unai misc. fixes/small optimization
- correct inline directive in Makefiles

TODO: 
- fix resolution change when loading savestates (easy gpu_unai fix)
- fix Xenogears textures
- make gpu_unai VRAM fill / copy functions more accurate
- adapt Rearmed's more accurate handling of GPU DMA command lists, VRAM transfers