### PR TITLE
Event queue and dynarec work

### DIFF
--- a/Makefile.caanoo
+++ b/Makefile.caanoo
@@ -67,10 +67,16 @@ OBJDIRS = obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) obj/interpreter obj/
 
 all: maketree $(TARGET) pcsx4all_caanoo.gpe
 
-OBJS = obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o obj/psxcounters.o \
-	obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/interpreter/$(INTERPRETER)/psxinterpreter.o obj/recompiler/$(RECOMPILER)/recompiler.o obj/recompiler/$(RECOMPILER)/run.o obj/gte/$(GTE)/gte.o  obj/mdec.o \
-	obj/decode_xa.o obj/cdriso.o obj/cdrom.o obj/ppf.o obj/sio.o obj/pad.o
+OBJS = \
+	obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o \
+	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/psxevents.o \
+	obj/interpreter/$(INTERPRETER)/psxinterpreter.o \
+	obj/recompiler/$(RECOMPILER)/recompiler.o obj/recompiler/$(RECOMPILER)/run.o \
+	obj/mdec.o \ obj/decode_xa.o \
+	obj/cdriso.o obj/cdrom.o obj/ppf.o \
+	obj/sio.o obj/pad.o
 
+OBJS += obj/gte/$(GTE)/gte.o
 OBJS += obj/gpu/$(GPU)/gpu.o
 
 ifneq ($(strip $(findstring arm,$(CFLAGS))),)

--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -74,7 +74,7 @@ all: maketree $(TARGET)
 
 OBJS = \
 	obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o \
-	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o \
+	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/psxevents.o \
 	obj/interpreter/$(INTERPRETER)/psxinterpreter.o \
 	obj/mdec.o obj/decode_xa.o \
 	obj/cdriso.o obj/cdrom.o obj/ppf.o \

--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -33,7 +33,7 @@ BIOS_FILE = \"scph1001.bin\"
 MCD1_FILE = \"mcd001.mcr\"
 MCD2_FILE = \"mcd002.mcr\"
 
-CFLAGS = -mips32r2 -ggdb3 -O2 -DGCW_ZERO \
+CFLAGS = -mips32r2 -mplt -mno-shared -ggdb3 -O2 -DGCW_ZERO \
 	 -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align \
 	 -Wno-unused-value -Wno-write-strings -Wno-narrowing \
 	 -Waggregate-return -Wno-cast-align \

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -70,7 +70,7 @@ all: maketree $(TARGET)
 
 OBJS = \
 	obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o \
-	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o \
+	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/psxevents.o \
 	obj/interpreter/$(INTERPRETER)/psxinterpreter.o \
 	obj/mdec.o obj/decode_xa.o \
 	obj/cdriso.o obj/cdrom.o obj/ppf.o \

--- a/Makefile.win32
+++ b/Makefile.win32
@@ -68,7 +68,7 @@ all: maketree $(TARGET)
 
 OBJS = \
 	obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o \
-	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o \
+	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/psxevents.o \
 	obj/interpreter/$(INTERPRETER)/psxinterpreter.o \
 	obj/mdec.o obj/decode_xa.o \
 	obj/cdriso.o obj/cdrom.o obj/ppf.o \

--- a/Makefile.wiz
+++ b/Makefile.wiz
@@ -72,10 +72,16 @@ OBJDIRS = obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) obj/interpreter obj/
 
 all: maketree $(TARGET) pcsx4all_wiz.gpe
 
-OBJS = obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o obj/psxcounters.o \
-	obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/interpreter/$(INTERPRETER)/psxinterpreter.o obj/recompiler/$(RECOMPILER)/recompiler.o obj/recompiler/$(RECOMPILER)/run.o obj/gte/$(GTE)/gte.o  obj/mdec.o \
-	obj/decode_xa.o obj/cdriso.o obj/cdrom.o obj/ppf.o obj/sio.o obj/pad.o
+OBJS = \
+	obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o \
+	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/psxevents.o \
+	obj/interpreter/$(INTERPRETER)/psxinterpreter.o \
+	obj/recompiler/$(RECOMPILER)/recompiler.o obj/recompiler/$(RECOMPILER)/run.o \
+	obj/mdec.o \ obj/decode_xa.o \
+	obj/cdriso.o obj/cdrom.o obj/ppf.o \
+	obj/sio.o obj/pad.o
 
+OBJS += obj/gte/$(GTE)/gte.o
 OBJS += obj/gpu/$(GPU)/gpu.o
 
 ifneq ($(strip $(findstring arm,$(CFLAGS))),)

--- a/src/cdrom.cpp
+++ b/src/cdrom.cpp
@@ -23,10 +23,7 @@
 */
 
 //senquack - NOTE May 23 2016:
-// This file has been updated to use newer code of PCSX Reloaded/Rearmed,
-// keeping a few tiny things here or there from PCSX4ALL code like calls
-// to ResetIoCycle() that could probably be removed (TODO) as I think they
-// were merely used for debugging during PCSX4ALL development/hackery.
+// This file has been updated to use newer code of PCSX Reloaded/Rearmed.
 // New bug fixes/updates come with the code, and also things like CD
 // lid interrupt for better CD swapping support.
 //
@@ -36,6 +33,9 @@
 // See https://github.com/notaz/pcsx_rearmed/blob/master/libpcsxcore/cdrom.c
 // for the source of updates to this code.
 // Credit goes to Notaz / PCSX Rearmed
+//
+//senquack - NOTE Aug 2 2016:
+// Additional updates to use new event queue (see psxevents.h)
 
 #include "cdrom.h"
 #include "ppf.h"
@@ -582,11 +582,6 @@ void cdrPlayInterrupt()
 
 	// update for CdlGetlocP/autopause
 	generate_subq(cdr.SetSectorPlay);
-
-	//senquack - Copy/pasted CHUI's ResetIoCycle() call into this new function
-	// TODO: Are these really beneficial/necessary?
-	// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
-	ResetIoCycle();
 }
 
 void cdrInterrupt()
@@ -1062,11 +1057,6 @@ finish:
 		SysPrintf("\n");
 	}
 #endif
-
-	//senquack - Copy/pasted CHUI's ResetIoCycle() call into this new function
-	// TODO: Are these really beneficial/necessary?
-	// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
-	ResetIoCycle();
 }
 
 #ifdef HAVE_ARMV7
@@ -1261,11 +1251,6 @@ void cdrReadInterrupt() {
 
 	// update for CdlGetlocP
 	ReadTrack(cdr.SetSectorPlay);
-
-	//senquack - Copy/pasted CHUI's ResetIoCycle() call into this new function
-	// TODO: Are these really beneficial/necessary?
-	// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
-	ResetIoCycle();
 }
 
 /*
@@ -1412,13 +1397,6 @@ void cdrWrite1(unsigned char rt) {
 		if( cdr.Play && (cdr.Mode & MODE_CDDA) == 0 )
 			StopCdda();
         	break;
-	}
-
-	//senquack - Copy/pasted CHUI's if (...) ResetIoCycle() call into this new function
-	// TODO: Are these really beneficial/necessary?
-	if (cdr.Stat != NoIntr) {
-		// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
-		ResetIoCycle();
 	}
 }
 

--- a/src/cdrom.cpp
+++ b/src/cdrom.cpp
@@ -279,6 +279,10 @@ static void setIrq(void)
 {
 	if (cdr.Stat & cdr.Reg2)
 		psxHu32ref(0x1070) |= SWAP32((u32)0x4);
+
+	// When IRQ status bit gets set, ensure psxBranchTest() gets called as soon
+	//  as possible, so HW IRQ exception gets handled
+	ResetIoCycle();
 }
 
 // timing used in this function was taken from tests on real hardware

--- a/src/cdrom.cpp
+++ b/src/cdrom.cpp
@@ -40,6 +40,7 @@
 #include "cdrom.h"
 #include "ppf.h"
 #include "psxdma.h"
+#include "psxevents.h"
 
 #if defined(CDR_LOG) || defined(CDR_LOG_I) || defined(CDR_LOG_IO)
 static const char *CmdName[0x100]= {
@@ -231,44 +232,29 @@ u16 calcCrc(const u8 *d, const int len) {
 
 // cdrInterrupt
 #define CDR_INT(eCycle) { \
-	ResetIoCycle(); \
-	psxRegs.interrupt |= (1 << PSXINT_CDR); \
-	psxRegs.intCycle[PSXINT_CDR].cycle = eCycle; \
-	psxRegs.intCycle[PSXINT_CDR].sCycle = psxRegs.cycle; \
+	psxEventQueue.enqueue(PSXINT_CDR, eCycle); \
 }
 
 // cdrReadInterrupt
 #define CDREAD_INT(eCycle) { \
-	ResetIoCycle(); \
-	psxRegs.interrupt |= (1 << PSXINT_CDREAD); \
-	psxRegs.intCycle[PSXINT_CDREAD].cycle = eCycle; \
-	psxRegs.intCycle[PSXINT_CDREAD].sCycle = psxRegs.cycle; \
+	psxEventQueue.enqueue(PSXINT_CDREAD, eCycle); \
 }
 
 //senquack - Next two interrupt macros are new from PCSX Reloaded/Rearmed.
-//           I have added calls to ResetIoCycle() to match above macros,
-//           but wasn't sure that was truly necessary (TODO)
-
 // cdrLidSeekInterrupt
 #define CDRLID_INT(eCycle) { \
-	ResetIoCycle(); \
-	psxRegs.interrupt |= (1 << PSXINT_CDRLID); \
-	psxRegs.intCycle[PSXINT_CDRLID].cycle = eCycle; \
-	psxRegs.intCycle[PSXINT_CDRLID].sCycle = psxRegs.cycle; \
+	psxEventQueue.enqueue(PSXINT_CDRLID, eCycle); \
 }
 
 // cdrPlayInterrupt
 #define CDRMISC_INT(eCycle) { \
-	ResetIoCycle(); \
-	psxRegs.interrupt |= (1 << PSXINT_CDRPLAY); \
-	psxRegs.intCycle[PSXINT_CDRPLAY].cycle = eCycle; \
-	psxRegs.intCycle[PSXINT_CDRPLAY].sCycle = psxRegs.cycle; \
+	psxEventQueue.enqueue(PSXINT_CDRPLAY, eCycle); \
 }
 
 #define StopReading() { \
 	if (cdr.Reading) { \
 		cdr.Reading = 0; \
-		psxRegs.interrupt &= ~(1 << PSXINT_CDREAD); \
+		psxEventQueue.dequeue(PSXINT_CDREAD); \
 	} \
 	cdr.StatP &= ~(STATUS_READ|STATUS_SEEK);\
 }

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -21,6 +21,7 @@
 #include "psxcommon.h"
 #include "psxmem.h"
 #include "r3000a.h"
+#include "psxevents.h"
 #include "debug.h"
 
 #ifdef DEBUG_PCSX4ALL

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -30,6 +30,7 @@
 #include "mdec.h"
 #include "gpu.h"
 #include "ppf.h"
+#include "psxevents.h"
 #include "port.h"
 
 #ifdef _WIN32
@@ -648,6 +649,12 @@ int LoadState(const char *file) {
 	psxRegs.cycle_add=0;
 	gzseek(f, gztell(f)-4, SEEK_SET);
 #endif
+
+	//senquack - Clear & intialize new event scheduler queue based on
+	// saved contents of psxRegs.interrupt and psxRegs.intCycle[]
+	// NOTE: important to do this before calling any functions like
+	// psxRcntFreeze() that will queue events of their own.
+	psxEventQueue.init_from_freeze();
 
 	if (Config.HLE)
 		psxBiosFreeze(0);

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -70,6 +70,34 @@ void ReleasePlugins(void) {
 	SPU_shutdown();
 }
 
+//senquack - UpdateSPU() provides a void(void) function that wraps
+// call to SPU_async(), allowing generic handling of event handlers
+// in r3000a.cpp psxBranchTest()
+void UpdateSPU(void)
+{
+#ifdef spu_pcsxrearmed
+	//Clear any scheduled SPUIRQ, as HW SPU IRQ will end up handled with
+	// this call to SPU_async(), and new SPUIRQ scheduled if necessary.
+	psxRegs.interrupt &= ~(1 << PSXINT_SPUIRQ);
+
+	SPU_async(psxRegs.cycle, 1);
+#else
+	SPU_async();
+#endif
+	SCHEDULE_SPU_UPDATE(spu_upd_interval);
+}
+
+//senquack - HandleSPU_IRQ() provides a void(void) function that wraps
+// call to SPU_async(), allowing generic handling of event handlers
+// in r3000a.cpp psxBranchTest(). NOTE: Only spu_pcsxrearmed actually
+// implements handling of SPU HW IRQs.
+void HandleSPU_IRQ(void)
+{
+#ifdef spu_pcsxrearmed
+	SPU_async(psxRegs.cycle, 0);
+#endif
+}
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -107,6 +107,8 @@ extern "C" {
 // SPU interrupt bit (currently only used by spu_pcsxrearmed)
 void CALLBACK Trigger_SPU_IRQ(void) {
 	psxHu32ref(0x1070) |= SWAPu32(0x200);
+	// Ensure psxBranchTest() is called soon when IRQ is pending:
+	ResetIoCycle();
 }
 
 //senquack - A generic function SPU plugins can use to schedule an update

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -23,6 +23,7 @@
 */
 
 #include "plugins.h"
+#include "psxevents.h"
 
 int LoadPlugins(void) {
 	int ret;
@@ -78,7 +79,7 @@ void UpdateSPU(void)
 #ifdef spu_pcsxrearmed
 	//Clear any scheduled SPUIRQ, as HW SPU IRQ will end up handled with
 	// this call to SPU_async(), and new SPUIRQ scheduled if necessary.
-	psxRegs.interrupt &= ~(1 << PSXINT_SPUIRQ);
+	psxEventQueue.dequeue(PSXINT_SPUIRQ);
 
 	SPU_async(psxRegs.cycle, 1);
 #else
@@ -115,9 +116,7 @@ void CALLBACK Trigger_SPU_IRQ(void) {
 //  Need for Speed 3, Metal Gear Solid, Chrono Cross, etc. and is currently
 //  only implemented in spu_pcsxrearmed)
 void CALLBACK Schedule_SPU_IRQ(unsigned int cycles_after) {
-	psxRegs.interrupt |= (1 << PSXINT_SPUIRQ);
-	psxRegs.intCycle[PSXINT_SPUIRQ].cycle = cycles_after;
-	psxRegs.intCycle[PSXINT_SPUIRQ].sCycle = psxRegs.cycle;
+	psxEventQueue.enqueue(PSXINT_SPUIRQ, cycles_after);
 }
 
 #ifdef __cplusplus

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -130,6 +130,10 @@ extern void SPU_playCDDAchannel(unsigned char *, int);
 #endif
 
 //senquack - added these two functions, see notes in plugins.cpp
+void UpdateSPU(void);
+void HandleSPU_IRQ(void);
+
+//senquack - added these two functions, see notes in plugins.cpp
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -141,13 +141,8 @@ extern "C" {
 void CALLBACK Trigger_SPU_IRQ(void);
 void CALLBACK Schedule_SPU_IRQ(unsigned int cycles_after);
 
-// senquack- TODO: add ResetIoCycle() like other older PCSX4ALL code has
-//  littered everywhere?
-//Note: There is no need to set a PSXINT flag in psxRegs.interrupts
-// for PSXINT_SPU_UPDATE, as SPU updates are always enabled/checked.
 #define SCHEDULE_SPU_UPDATE(eCycle) { \
-	psxRegs.intCycle[PSXINT_SPU_UPDATE].cycle = eCycle; \
-	psxRegs.intCycle[PSXINT_SPU_UPDATE].sCycle = psxRegs.cycle; \
+	psxEventQueue.enqueue(PSXINT_SPU_UPDATE, eCycle); \
 }
 
 #ifdef __cplusplus

--- a/src/psxcounters.h
+++ b/src/psxcounters.h
@@ -27,7 +27,6 @@
 #include "psxmem.h"
 #include "plugins.h"
 
-extern u32 psxNextCounter, psxNextsCounter;
 extern u32 hSyncCount, frame_counter;
 extern u32 spu_upd_interval;
 
@@ -52,5 +51,8 @@ extern u32 psxRcntRtarget(u32 index);
 extern s32 psxRcntFreeze(gzFile f, s32 Mode);
 
 extern unsigned psxGetSpuSync(void);
+
+// senquack - Called before psxRegs.cycle is adjusted back to zero
+void psxRcntAdjustTimestamps(const uint32_t prev_cycle_val);
 
 #endif /* __PSXCOUNTERS_H__ */

--- a/src/psxdma.h
+++ b/src/psxdma.h
@@ -23,53 +23,35 @@
 
 #include "psxcommon.h"
 #include "r3000a.h"
+#include "psxevents.h"
 #include "psxhw.h"
 #include "psxmem.h"
 
 //senquack - NOTE: These macros have been updated to use new PSXINT_*
 // interrupts enum and intCycle struct (much cleaner than before)
-// from PCSX Reloaded/Rearmed
-
-// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
+// from PCSX Reloaded/Rearmed as well as new event queue (psxevents.h)
 #define GPUDMA_INT(eCycle) { \
-	ResetIoCycle(); \
-	psxRegs.interrupt |= (1 << PSXINT_GPUDMA); \
-	psxRegs.intCycle[PSXINT_GPUDMA].cycle = eCycle; \
-	psxRegs.intCycle[PSXINT_GPUDMA].sCycle = psxRegs.cycle; \
+	psxEventQueue.enqueue(PSXINT_GPUDMA, eCycle); \
 }
 
-// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
 #define SPUDMA_INT(eCycle) { \
-    ResetIoCycle(); \
-	psxRegs.interrupt |= (1 << PSXINT_SPUDMA); \
-	psxRegs.intCycle[PSXINT_SPUDMA].cycle = eCycle; \
-	psxRegs.intCycle[PSXINT_SPUDMA].sCycle = psxRegs.cycle; \
+	psxEventQueue.enqueue(PSXINT_SPUDMA, eCycle); \
 }
 
-// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
 #define MDECOUTDMA_INT(eCycle) { \
-	ResetIoCycle(); \
-	psxRegs.interrupt |= (1 << PSXINT_MDECOUTDMA); \
-	psxRegs.intCycle[PSXINT_MDECOUTDMA].cycle = eCycle; \
-	psxRegs.intCycle[PSXINT_MDECOUTDMA].sCycle = psxRegs.cycle; \
+	psxEventQueue.enqueue(PSXINT_MDECOUTDMA, eCycle); \
 }
 
 #define MDECINDMA_INT(eCycle) { \
-	psxRegs.interrupt |= (1 << PSXINT_MDECINDMA); \
-	psxRegs.intCycle[PSXINT_MDECINDMA].cycle = eCycle; \
-	psxRegs.intCycle[PSXINT_MDECINDMA].sCycle = psxRegs.cycle; \
+	psxEventQueue.enqueue(PSXINT_MDECINDMA, eCycle); \
 }
 
 #define GPUOTCDMA_INT(eCycle) { \
-	psxRegs.interrupt |= (1 << PSXINT_GPUOTCDMA); \
-	psxRegs.intCycle[PSXINT_GPUOTCDMA].cycle = eCycle; \
-	psxRegs.intCycle[PSXINT_GPUOTCDMA].sCycle = psxRegs.cycle; \
+	psxEventQueue.enqueue(PSXINT_GPUOTCDMA, eCycle); \
 }
 
 #define CDRDMA_INT(eCycle) { \
-	psxRegs.interrupt |= (1 << PSXINT_CDRDMA); \
-	psxRegs.intCycle[PSXINT_CDRDMA].cycle = eCycle; \
-	psxRegs.intCycle[PSXINT_CDRDMA].sCycle = psxRegs.cycle; \
+	psxEventQueue.enqueue(PSXINT_CDRDMA, eCycle); \
 }
 
 void psxDma2(u32 madr, u32 bcr, u32 chcr);

--- a/src/psxevents.cpp
+++ b/src/psxevents.cpp
@@ -1,0 +1,226 @@
+/***************************************************************************
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02111-1307 USA.           *
+ ***************************************************************************/
+
+/*
+ * Event / interrupt scheduling
+ *
+ * Added July 2016 by senquack (Daniel Silsby)
+ */
+
+#include "psxevents.h"
+#include "r3000a.h"
+#include "debug.h"
+
+// To get event-handler functions:
+#include "cdrom.h"
+#include "plugins.h"
+#include "psxdma.h"
+#include "mdec.h"
+
+// psxBranchTest() debug statistics
+#ifdef DEBUG_EVENTS
+unsigned int bt_necessary, bt_unnecessary;
+#endif
+
+// When psxRegs.cycle is >= this figure, it gets reset to 0:
+static const uint32_t reset_cycle_val_at = 2000000000;
+
+// Function called when PSXINT_RESET_CYCLE_VAL event occurs:
+// psxRegs.cycle is now regularly reset to 0 instead of being allowed to
+// overflow. This ensures that it can always be compared directly to
+// psxRegs.io_cycle_counter to know if psxBranchTest() needs to be called.
+static void psxResetCycleValue()
+{
+#ifdef DEBUG_EVENTS
+    /* psxBranchTest() debug statistics */
+	printf("\n\nResetting cycle value %u  io_cycle_counter: %u\n", psxRegs.cycle, psxRegs.io_cycle_counter);
+	printf("bt_necessary: %u  bt_unnecessary: %u\n", bt_necessary, bt_unnecessary);
+	bt_necessary = bt_unnecessary = 0;
+	//printf("bt_cp0_irq_enable: %u  bt_cp0_irq_disable: %u\n", bt_cp0_irq_enable, bt_cp0_irq_disable);
+	//bt_cp0_irq_enable = bt_cp0_irq_disable = 0;
+	psxEventQueue.print_event_queue();
+#endif
+
+	// Any events in the queue must be adjusted to match:
+	psxEventQueue.adjust_event_timestamps(psxRegs.cycle);
+
+	// All root-counter timestamps must also be adjusted:
+	psxRcntAdjustTimestamps(psxRegs.cycle);
+
+	// Reset cycle counter and enqueue new reset event:
+	psxRegs.cycle = 0;
+	psxEventQueue.enqueue(PSXINT_RESET_CYCLE_VAL, reset_cycle_val_at);
+
+#ifdef DEBUG_EVENTS
+	psxEventQueue.print_event_queue();
+	printf("io_cycle_counter: %u\n", psxRegs.io_cycle_counter);
+	printf("------------------------------------------\n\n");
+#endif
+}
+
+void EventQueue::schedule_persistent_events()
+{
+	// Call psxResetCycleValue() once, which will take care of two things:
+	//  1.) psxRegs.cycle value is reset to 0, important if loading a savestate
+	//      from an older version of emu, and psxRegs.cycle might be huge value
+	//  2.) schedule PSXINT_RESET_CYCLE_VAL event, which calls it again
+	//      at regular, very infrequent, intervals
+	psxResetCycleValue();
+
+	// Must schedule initial SPU update.. it will reschedule itself thereafter
+	SCHEDULE_SPU_UPDATE(spu_upd_interval);
+}
+
+void EventQueue::enqueue(const psxEventType ev, const uint32_t cycles_after)
+{
+	// Dequeue event if it already exists, to match original emu behavior
+	if (contains(ev))
+		queue.remove(ev);
+
+	psxRegs.interrupt |= (uint32_t)1 << ev;
+	psxRegs.intCycle[ev].sCycle = psxRegs.cycle;
+	psxRegs.intCycle[ev].cycle = cycles_after;
+	EventMoreImminent sort_functor; // Functor to sort queue entries by
+	queue.insert((uint8_t)ev, sort_functor);
+	psxRegs.intCycle[PSXINT_NEXT_EVENT] = psxRegs.intCycle[queue.front()];
+
+	// psxRegs.io_cycle_counter is used by interpreter/recompiler to determine
+	//  when next to call psxBranchTest()
+	psxRegs.io_cycle_counter = psxRegs.intCycle[PSXINT_NEXT_EVENT].sCycle + psxRegs.intCycle[PSXINT_NEXT_EVENT].cycle;
+}
+
+void EventQueue::dequeue(const psxEventType ev)
+{
+	if (!contains(ev))
+		return;
+
+	queue.remove(ev);
+	psxRegs.interrupt &= ~((uint32_t)1 << ev);
+
+	// If additional events were also scheduled, copy the next most-imminent
+	//  event's timestamp into PSXINT_NEXT_EVENT entry:
+	// (At least one event will always remain scheduled, i.e. PSXINT_RCNT
+	//  or PSXINT_SPU_UPDATE, so this check for emptiness is not really needed)
+	if (!queue.empty()) {
+		psxRegs.intCycle[PSXINT_NEXT_EVENT] = psxRegs.intCycle[queue.front()];
+
+		// io_cycle_counter is used by interpreter/recompiler to determine next
+		//  time to call psxBranchTest()
+		psxRegs.io_cycle_counter = psxRegs.intCycle[PSXINT_NEXT_EVENT].sCycle + psxRegs.intCycle[PSXINT_NEXT_EVENT].cycle;
+	} else {
+		// Shouldn't happen, but set to 0 just in case:
+		psxRegs.io_cycle_counter = 0;
+	}
+}
+
+void EventQueue::dispatch_and_remove_front()
+{
+#ifdef DEBUG_EVENTS
+	if (queue.empty()) {
+		printf("Error: EventQueue::dispatch_and_remove_front() called when queue is empty\n");
+		return;
+	}
+#endif
+
+	uint8_t ev = queue.front();
+	queue.remove_front();
+	psxRegs.interrupt &= ~((uint32_t)1 << ev);
+
+#ifdef DEBUG_EVENTS
+	if (eventFuncs[ev] == event_stub_func) {
+		printf("event_stub_func() called in EventQueue for unimplemented event %u\n", ev);
+	}
+#endif
+
+	eventFuncs[ev]();  // Dispatch event
+
+	// Queue can never be totally empty, as certain persistent events will
+	//  always be rescheduled during dispatch above.
+#ifdef DEBUG_EVENTS
+	if (queue.empty())
+		printf("ERROR: empty queue after EventQueue::dispatch_and_remove_front()\n");
+#endif
+
+	psxRegs.intCycle[PSXINT_NEXT_EVENT] = psxRegs.intCycle[queue.front()];
+}
+
+void EventQueue::init_from_freeze()
+{
+	queue.clear();
+	EventMoreImminent sort_functor; // Functor to sort queue entries by
+	for (uint8_t i=0; i < PSXINT_COUNT; ++i) {
+		if (psxRegs.interrupt & ((uint32_t)1 << i)) {
+			queue.insert(i, sort_functor);
+		}
+	}
+
+	schedule_persistent_events();
+
+	// Don't trust io_cycle_counter from a freeze (determines next call to
+	//  psxBranchTest() from interpreter/recompiler, which also handles
+	//  issuing HW IRQ exceptions which might have been pending at save.)
+	psxRegs.io_cycle_counter = 0;
+}
+
+void EventQueue::event_stub_func()
+{
+}
+
+#ifdef DEBUG_EVENTS
+void EventQueue::print_event_queue()
+{
+	printf("Queue contains %u events:\n", queue.size());
+	for (uint8_t *ev = queue.front_ptr(); ev != queue.end_ptr(); ++ev) {
+		printf("EV: %u SCYCLE: %u CYCLE: %u\n", *ev, psxRegs.intCycle[*ev].sCycle, psxRegs.intCycle[*ev].cycle);
+	}
+
+	// Consistent ordering check:
+	for (uint8_t *ev = queue.front_ptr(); ev != queue.end_ptr(); ++ev) {
+		EventMoreImminent compare_func;
+		if (ev < (queue.end_ptr() - 1)) {
+			if (!compare_func(*ev, *(ev+1))) {
+				if ((psxRegs.intCycle[*ev].sCycle + psxRegs.intCycle[*ev].cycle) !=
+					(psxRegs.intCycle[*(ev+1)].sCycle + psxRegs.intCycle[*(ev+1)].cycle)) {
+					printf("ERROR: EV %u > EV %u\n", *ev, *(ev+1));
+				}
+			}
+		}
+	}
+}
+#endif
+
+EventQueue::EventFunc * const EventQueue::eventFuncs[PSXINT_COUNT] = {
+	[PSXINT_SIO]             = sioInterrupt,
+	[PSXINT_CDR]             = cdrInterrupt,
+	[PSXINT_CDREAD]          = cdrReadInterrupt,
+	[PSXINT_GPUDMA]          = gpuInterrupt,
+	[PSXINT_MDECOUTDMA]      = mdec1Interrupt,
+	[PSXINT_SPUDMA]          = spuInterrupt,
+	[PSXINT_GPUBUSY]         = EventQueue::event_stub_func, // UNIMPLEMENTED (TODO?)
+	[PSXINT_MDECINDMA]       = mdec0Interrupt,
+	[PSXINT_GPUOTCDMA]       = gpuotcInterrupt,
+	[PSXINT_CDRDMA]          = cdrDmaInterrupt,
+	[PSXINT_NEWDRC_CHECK]    = EventQueue::event_stub_func, // UNIMPLEMENTED (TODO?)
+	[PSXINT_RCNT]            = psxRcntUpdate,
+	[PSXINT_CDRLID]          = cdrLidSeekInterrupt,
+	[PSXINT_CDRPLAY]         = cdrPlayInterrupt,
+	[PSXINT_SPUIRQ]          = HandleSPU_IRQ,
+	[PSXINT_SPU_UPDATE]      = UpdateSPU,
+	[PSXINT_RESET_CYCLE_VAL] = psxResetCycleValue
+};
+
+EventQueue psxEventQueue;

--- a/src/psxevents.h
+++ b/src/psxevents.h
@@ -1,0 +1,311 @@
+/***************************************************************************
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02111-1307 USA.           *
+ ***************************************************************************/
+
+/*
+ * Event / interrupt scheduling
+ *
+ * Added July 2016 by senquack (Daniel Silsby)
+ *
+ * Class MinQueue is based largely on OpenMSX's SchedulerQueue class, found
+ *  here: https://github.com/openMSX/openMSX/blob/master/src/SchedulerQueue.hh
+ *  (Which was primarily written by Wouter Vermaelen a.k.a. m9710797
+ */
+
+#ifndef PSXEVENTS_H
+#define PSXEVENTS_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include "r3000a.h"
+
+enum psxEventType {
+	PSXINT_SIO = 0,
+	PSXINT_CDR,
+	PSXINT_CDREAD,
+	PSXINT_GPUDMA,
+	PSXINT_MDECOUTDMA,
+	PSXINT_SPUDMA,
+	PSXINT_GPUBUSY,        //From PCSX Rearmed, but not implemented there nor here
+	PSXINT_MDECINDMA,
+	PSXINT_GPUOTCDMA,
+	PSXINT_CDRDMA,
+	PSXINT_NEWDRC_CHECK,   //From PCSX Rearmed, but not implemented here (TODO?)
+	PSXINT_RCNT,
+	PSXINT_CDRLID,
+	PSXINT_CDRPLAY,
+	PSXINT_SPUIRQ,         //Check for upcoming SPU HW interrupts
+	PSXINT_SPU_UPDATE,     //senquack - update and feed SPU (note that this usage
+	                       // differs from Rearmed: Rearmed uses this for checking
+	                       // for SPU HW interrupts and lacks a flexibly-scheduled
+	                       // interval for SPU update-and-feed)
+	PSXINT_RESET_CYCLE_VAL,          // Reset psxRegs.cycle value to 0 to ensure
+	                                 //  it can never overflow
+	PSXINT_COUNT,
+	PSXINT_NEXT_EVENT = PSXINT_COUNT //The most imminent event's entry is
+	                                 // always copied to this slot in
+	                                 // psxRegs.intCycles[] for fast checking
+};
+
+// This is similar to a sorted vector<T>, though this container can have spare
+//  capacity both at the front and at the end (vector only at the end). This
+//  means that when you remove the 'smallest' element and insert a new element
+//  that's only slightly 'bigger' than the smallest one, there's a very good
+//  chance this insert runs in O(1) (for vector it's O(N), with N the size of
+//  the vector). This is a scenario that occurs very often in the scheduler
+//  code.
+template<typename T, typename T_IDX_TYPE, size_t T_CAPACITY, size_t T_SPARE_FRONT>
+class SortedArray {
+public:
+	SortedArray() { clear(); }
+
+	void clear()
+	{
+		useBeginIdx = T_SPARE_FRONT;
+		useEndIdx = useBeginIdx;
+	}
+
+	size_t capacity() const { return T_CAPACITY; }
+	size_t spare_front() const { return useBeginIdx; }
+	size_t spare_back() const { return T_CAPACITY - useEndIdx; }
+	size_t size() const { return useEndIdx - useBeginIdx; }
+	bool empty() const { return useEndIdx == useBeginIdx; }
+
+	// Returns reference to the first element in use
+	T& front() { return storage[useBeginIdx]; }
+	const T& front() const { return storage[useBeginIdx]; }
+
+	// Returns pointer to the first element in use
+	T* front_ptr() { return storage + useBeginIdx; }
+	const T* front_ptr() const { return storage + useBeginIdx; }
+
+	// Returns pointer to one past the last element in use,
+	//  but when empty, points to same element as front_ptr()
+	T* end_ptr() { return storage + useEndIdx; }
+	const T* end_ptr() const { return storage + useEndIdx; }
+
+	bool contains(const T& t) const
+	{
+		const T *it = front_ptr();
+		while ((it != end_ptr()) && (*it != t))
+			++it;
+		return it != end_ptr();
+	}
+
+	// Insert new element.
+	//  Elements are sorted according to the given predicate. Predicate
+	//  will return 'true' for sort_pred(ELEMENT_BEFORE, ELEMENT_AFTER).
+	//  Important: two elements that are equivalent according to predicate
+	//  keep their relative order, i.e., newly-inserted elements are inserted
+	//  after existing equivalent elements.
+	template<typename T_SORT_PREDICATE>
+	void insert(const T& t, T_SORT_PREDICATE sort_pred)
+	{
+		T* it = front_ptr();
+
+		while ((it != end_ptr()) && !sort_pred(t, *it))
+			++it;
+
+		// Determine if insertion point is closer to beginning of used space,
+		//  so the minimum amount of data must be rearranged
+		if ((it - front_ptr()) <= (end_ptr() - it)) {
+			// Closer to beginning, so moving preceding elements backwards is best
+			if (useBeginIdx != 0) {
+				// Insert at position 'it-1', moving backward all elements between
+				//  that position and the front
+				insert_front(it, t);
+			} else if (useEndIdx != T_CAPACITY) {
+				// Insert at position 'it', moving forward all elements between that
+				//  position and the end
+				insert_back(it, t);
+			} else {
+#ifdef DEBUG_EVENTS
+				dbg("ERROR: SchedulerQueue::insert() could not find space in its array (1)\n");
+#endif
+			}
+		} else {
+			// Closer to end, so moving succeeding elements forwards is best
+			if (useEndIdx != T_CAPACITY) {
+				// Insert at position 'it', moving forward all elements between that
+				//  position and the end
+				insert_back(it, t);
+			} else if (useBeginIdx != 0) {
+				// Insert at position 'it-1', moving backward all elements between
+				//  that position and the front
+				insert_front(it, t);
+			} else {
+#ifdef DEBUG_EVENTS
+				dbg("ERROR: SchedulerQueue::insert() could not find space in its array (2)\n");
+#endif
+			}
+		}
+	}
+
+	// Remove the head of the sorted array
+	void remove_front()
+	{
+		assert(!empty());
+		++useBeginIdx;
+	}
+
+	// Remove the first matching element, returning false if not found
+	bool remove(const T& t)
+	{
+		T *it = front_ptr();
+		while ((it != end_ptr()) && (*it != t))
+			++it;
+
+		if (it == end_ptr())
+			return false;
+
+		if ((it - front_ptr()) < (end_ptr() - it - 1)) {
+			// Element is closer to the beginning of the array
+			move_forward(front_ptr(), it - 1);
+			++useBeginIdx;
+		} else {
+			// Element is closer to the end of the array
+			--useEndIdx;
+			move_backward(it + 1, end_ptr());
+		}
+		return true;
+	}
+
+private:
+	// Copy all elements between [start,end] to [start+1,end+1].
+	//  If start address is greater than end, no copy will occur.
+	void move_forward(T* const start, T* const end)
+	{
+		for (T* ptr = end; ptr >= start; --ptr)
+			*(ptr + 1) = *ptr;
+	}
+
+	// Copy all elements between [start,end] to [start-1,end-1].
+	//  If start address is greater than end, no copy will occur.
+	void move_backward(T* const start, T* const end)
+	{
+		for (T* ptr = start; ptr <= end; ++ptr)
+			*(ptr - 1) = *ptr;
+	}
+
+	// Insert new entry 't' before position 'it'. Array contents before the
+	//  position will be moved backward before insertion.
+	void insert_front(T* it, const T& t)
+	{
+		--it;
+		move_backward(front_ptr(), it);
+		--useBeginIdx;
+		*it = t;
+	}
+
+	// Insert new entry 't' at position 'it'. Array contents between that
+	//  position and the end will be moved forwards before the insertion.
+	void insert_back(T* it, const T& t)
+	{
+		move_forward(it, end_ptr() - 1);
+		++useEndIdx;
+		*it = t;
+	}
+
+private:
+	T_IDX_TYPE useBeginIdx;    // Index of first used element of storage[] 
+	T_IDX_TYPE useEndIdx;      // One past last used index of storage[], or same
+	                           //  value as useBeginIdx when queue is empty.
+	T storage[T_CAPACITY];
+};
+
+class EventQueue {
+public:
+	// Schedule an event to occur after 'cycles_after' have passed from now.
+	//  If it's already enqueued, it will be rescheduled, without
+	//  calling its handler function.
+	void enqueue(const psxEventType ev, const uint32_t cycles_after);
+
+	// Unschedule an event, without calling its handler function.
+	void dequeue(const psxEventType ev);
+
+	// Remove the front of the queue and call its handler function:
+	void dispatch_and_remove_front();
+
+	uint8_t front() const { return queue.front(); }
+	bool    empty() const { return queue.empty(); }
+	size_t  size()  const { return queue.size(); }
+	void    clear_internal_queue() { return queue.clear(); }
+
+	bool contains(const psxEventType ev) const
+	{
+		// If an event is present in the queue, it must also be set in
+		//  psxRegs.interrupt, and is faster to just check that:
+		return psxRegs.interrupt & ((uint32_t)1 << ev);
+	}
+
+	// Certain events should always be scheduled when either starting
+	//  the emulator for the first time, restarting a game, or
+	//  loading a save-state. By ensuring these events are always loaded
+	//  on save-state load, compatibility with savestates from before
+	//  event-system overhaul is ensured.
+	void schedule_persistent_events();
+
+	// Build the event queue afresh from psxRegs.interrupt and psxRegs.intCycle[]
+	void init_from_freeze();
+
+	// At very intermittent intervals, psxRegs.cycle is reset to 0 to prevent
+	//  it from ever overflowing (simplifies checks against it elsewhere).
+	//  This function fixes up timestamps of all queued events when this occurs.
+	void adjust_event_timestamps(const uint32_t prev_cycle_val)
+	{
+		for (uint8_t *ev = queue.front_ptr(); ev != queue.end_ptr(); ++ev) {
+			psxRegs.intCycle[*ev].sCycle -= prev_cycle_val;
+		}
+
+		psxRegs.intCycle[PSXINT_NEXT_EVENT].sCycle -= prev_cycle_val;
+	}
+
+	// Functor specifying sort criteria to SortedArray member class
+	struct EventMoreImminent {
+		inline bool operator()(const uint8_t &lh, const uint8_t &rh) const
+		{
+			// Compare the two event timestamps, interpreting the result as a signed
+			//  integer in case one or both cross psxRegs.cycle overflow boundary.
+			int lh_tmp = psxRegs.intCycle[lh].sCycle + psxRegs.intCycle[lh].cycle - psxRegs.cycle;
+			int rh_tmp = psxRegs.intCycle[rh].sCycle + psxRegs.intCycle[rh].cycle - psxRegs.cycle;
+			return lh_tmp < rh_tmp;
+		}
+	};
+
+#ifdef DEBUG_EVENTS
+	void print_event_queue();
+#endif
+
+private:
+	SortedArray<uint8_t, uint8_t, PSXINT_COUNT, 2> queue;
+
+	// If a PSXINT_* event number is not implemented, call this stub
+	//  (should never happen)
+	static void event_stub_func();
+
+	// Event handler function table:
+	typedef void (EventFunc)();
+	static EventFunc * const eventFuncs[PSXINT_COUNT];
+};
+
+extern EventQueue psxEventQueue;
+
+/* psxBranchTest() debug statistics */
+#ifdef DEBUG_EVENTS
+extern unsigned int bt_necessary, bt_unnecessary;
+#endif
+
+#endif //PSXEVENTS_H

--- a/src/psxhw.cpp
+++ b/src/psxhw.cpp
@@ -29,9 +29,6 @@
 #include "profiler.h"
 
 void psxHwReset() {
-// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
-    ResetIoCycle();
-
 	//senquack - added Config.SpuIrq option from PCSX Rearmed/Reloaded:
 	if (Config.SpuIrq) psxHu32ref(0x1070) |= SWAP32(0x200);
 
@@ -655,13 +652,19 @@ void psxHwWrite16(u32 add, u16 value) {
 #ifdef PSXHW_LOG
 			PSXHW_LOG("IREG 16bit write %x\n", value);
 #endif
-// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
-			ResetIoCycle();
+			//senquack - Strip all but bits 0:10, rest are 0 or garbage in docs
+			value &= 0x7ff;
 
 			//senquack - added Config.SpuIrq option from PCSX Rearmed/Reloaded:
 			if (Config.SpuIrq) psxHu16ref(0x1070) |= SWAPu16(0x200);
 
 			psxHu16ref(0x1070) &= SWAPu16(value);
+
+			//senquack - When IRQ is pending and unmasked, ensure psxBranchTest()
+			// gets called as soon as possible, so HW IRQ exception gets handled
+			if (psxHu16(0x1070) & psxHu16(0x1074))
+				ResetIoCycle();
+
 #if defined(USE_CYCLE_ADD) || defined(DEBUG_CPU_OPCODES)
 			psxRegs.cycle-=psxRegs.cycle_add;psxRegs.cycle_add=0;
 #endif
@@ -672,9 +675,16 @@ void psxHwWrite16(u32 add, u16 value) {
 #ifdef PSXHW_LOG
 			PSXHW_LOG("IMASK 16bit write %x\n", value);
 #endif
-// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
-			ResetIoCycle();
+			//senquack - Strip all but bits 0:10, rest are 0 or garbage in docs
+			value &= 0x7ff;
+
 			psxHu16ref(0x1074) = SWAPu16(value);
+
+			//senquack - When IRQ is pending and unmasked, ensure psxBranchTest()
+			// gets called as soon as possible, so HW IRQ exception gets handled
+			if (psxHu16(0x1070) & psxHu16(0x1074))
+				ResetIoCycle();
+
 #if defined(USE_CYCLE_ADD) || defined(DEBUG_CPU_OPCODES)
 			psxRegs.cycle-=psxRegs.cycle_add;psxRegs.cycle_add=0;
 #endif
@@ -850,13 +860,19 @@ void psxHwWrite32(u32 add, u32 value) {
 #ifdef PSXHW_LOG
 			PSXHW_LOG("IREG 32bit write %x\n", value);
 #endif
-// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
-			ResetIoCycle();
+			//senquack - Strip all but bits 0:10, rest are 0 or garbage in docs
+			value &= 0x7ff;
 
 			//senquack - added Config.SpuIrq option from PCSX Rearmed/Reloaded:
 			if (Config.SpuIrq) psxHu32ref(0x1070) |= SWAPu32(0x200);
 
 			psxHu32ref(0x1070) &= SWAPu32(value);
+
+			//senquack - When IRQ is pending and unmasked, ensure psxBranchTest()
+			// gets called as soon as possible, so HW IRQ exception gets handled
+			if (psxHu32(0x1070) & psxHu32(0x1074))
+				ResetIoCycle();
+
 #if defined(USE_CYCLE_ADD) || defined(DEBUG_CPU_OPCODES)
 			psxRegs.cycle-=psxRegs.cycle_add;psxRegs.cycle_add=0;
 #endif
@@ -866,9 +882,16 @@ void psxHwWrite32(u32 add, u32 value) {
 #ifdef PSXHW_LOG
 			PSXHW_LOG("IMASK 32bit write %x\n", value);
 #endif
-// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
-			ResetIoCycle();
+			//senquack - Strip all but bits 0:10, rest are 0 or garbage in docs
+			value &= 0x7ff;
+
 			psxHu32ref(0x1074) = SWAPu32(value);
+
+			//senquack - When IRQ is pending and unmasked, ensure psxBranchTest()
+			// gets called as soon as possible, so HW IRQ exception gets handled
+			if (psxHu32(0x1070) & psxHu32(0x1074))
+				ResetIoCycle();
+
 #if defined(USE_CYCLE_ADD) || defined(DEBUG_CPU_OPCODES)
 			psxRegs.cycle-=psxRegs.cycle_add;psxRegs.cycle_add=0;
 #endif

--- a/src/r3000a.cpp
+++ b/src/r3000a.cpp
@@ -398,16 +398,8 @@ void psxBranchTest() {
 	// NOTE: PSXINT_SPU_UPDATE is always active and checked, it does not
 	//  set or check a flag of its own in psxRegs.interrupts.
 	if ((psxRegs.cycle - psxRegs.intCycle[PSXINT_SPU_UPDATE].sCycle) >= psxRegs.intCycle[PSXINT_SPU_UPDATE].cycle) {
-#ifdef spu_pcsxrearmed
-		//Clear any scheduled SPUIRQ, as HW SPU IRQ will end up handled with
-		// this call to SPU_async(), and new SPUIRQ scheduled if necessary.
-		psxRegs.interrupt &= ~(1 << PSXINT_SPUIRQ);
-
-		SPU_async(psxRegs.cycle, 1);
-#else
-		SPU_async();
-#endif
-		SCHEDULE_SPU_UPDATE(spu_upd_interval);
+		// No need to clear SPU update interrupt, it will just be rescheduled immediately
+		UpdateSPU();
 	}
 
 	if (psxRegs.interrupt) {
@@ -520,7 +512,7 @@ void psxBranchTest() {
 		if (psxRegs.interrupt & (1 << PSXINT_SPUIRQ)) { // scheduled spu HW IRQ update
 			if ((psxRegs.cycle - psxRegs.intCycle[PSXINT_SPUIRQ].sCycle) >= psxRegs.intCycle[PSXINT_SPUIRQ].cycle) {
 				psxRegs.interrupt &= ~(1 << PSXINT_SPUIRQ);
-				SPU_async(psxRegs.cycle, 0);
+				HandleSPU_IRQ();
 			}
 		}
 #endif

--- a/src/r3000a.cpp
+++ b/src/r3000a.cpp
@@ -151,8 +151,6 @@ void psxException(u32 code, u32 bd) {
 	// Set the Status
 	psxRegs.CP0.n.Status = (psxRegs.CP0.n.Status &~0x3f) |
 						  ((psxRegs.CP0.n.Status & 0xf) << 2);
-// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
-	ResetIoCycle();
 
 	if (!Config.HLE && (((PSXMu32(psxRegs.CP0.n.EPC) >> 24) & 0xfe) == 0x4a)) {
 		// "hokuto no ken" / "Crash Bandicot 2" ... fix

--- a/src/r3000a.h
+++ b/src/r3000a.h
@@ -142,27 +142,10 @@ typedef union {
 	PAIR p[32];
 } psxCP2Ctrl;
 
-enum {
-	PSXINT_SIO = 0,
-	PSXINT_CDR,
-	PSXINT_CDREAD,
-	PSXINT_GPUDMA,
-	PSXINT_MDECOUTDMA,
-	PSXINT_SPUDMA,
-	PSXINT_GPUBUSY,
-	PSXINT_MDECINDMA,
-	PSXINT_GPUOTCDMA,
-	PSXINT_CDRDMA,
-	PSXINT_NEWDRC_CHECK,
-	PSXINT_RCNT,          //senquack - not used (see psxcounters.cpp)
-	PSXINT_CDRLID,
-	PSXINT_CDRPLAY,
-	PSXINT_SPUIRQ,        //senquack - check for upcoming SPU HW interrupts
-	PSXINT_SPU_UPDATE,    //senquack - update and feed SPU (note that this usage
-                          // differs from Rearmed: Rearmed uses this for checking
-                          // for SPU HW interrupts and lacks a flexibly-scheduled
-                          // interval for SPU update-and-feed)
-	PSXINT_COUNT
+// Interrupt/event 'timestamp'
+struct intCycle_t {
+	u32 sCycle; // psxRegs.cycle value when event/interrupt was sheduled
+	u32 cycle;  // Number of cycles past sCycle above when event should occur
 };
 
 typedef struct {
@@ -175,9 +158,7 @@ typedef struct {
 	u32 cycle;
 	u32 interrupt;
 
-	//senquack - Converted to newer PCSXR struct:
-	//u32 intCycle[32];
-	struct { u32 sCycle, cycle; } intCycle[32];
+	intCycle_t intCycle[32];
 
 // CHUI: Añado los ciclos hasta el proximo evento.
 	u32 io_cycle_counter;
@@ -284,12 +265,27 @@ extern void psxReset(void);
 extern void psxShutdown(void);
 extern void psxException(u32 code, u32 bd);
 extern void psxBranchTest(void);
+
+
+//-----------------------------------------------------------------------------
+// senquack - disabled the old inefficient, extremely ugly versions of
+//  psxBranchTest() and associated functions psxCalculateIoCycle(),
+//  psxBranchTestCalculate() after event-scheduling overhaul (see psxevents.h).
+//  These were used by old ARM recompiler and interpreter_new, which are
+//  also uncommented messes.
+//  TODO: remove these entirely?
+//-----------------------------------------------------------------------------
+#if 0
 #ifdef USE_BRANCH_TEST_CALCULATE
 // CHUI: Funcion que llama a psxBranchTest y luego psxCalculateIoCycle
 extern void psxBranchTestCalculate();
 #else
 #define psxBranchTestCalculate psxBranchTest
 #endif
+#endif //0
+#define psxBranchTestCalculate psxBranchTest
+
+
 extern void psxExecuteBios(void);
 extern int  psxTestLoadDelay(int reg, u32 tmp);
 extern void psxDelayTest(int reg, u32 bpc);

--- a/src/recompiler/mips/mips_codegen.h
+++ b/src/recompiler/mips/mips_codegen.h
@@ -218,11 +218,29 @@ do { \
 #define SLTU(rd, rs, rt) \
 	write32(0x0000002b | (rs << 21) | (rt << 16) | (rd << 11))
 
+#define JAL(func) \
+	write32(0x0c000000 | (((u32)(func) & 0x0fffffff) >> 2))
+
+#define JR(rs) \
+	write32(0x00000008 | ((rs) << 21))
+
 #define BEQ(rs, rt, offset) \
 	write32(0x10000000 | (rs << 21) | (rt << 16) | (offset >> 2))
 
 #define BEQZ(rs, offset)	BEQ(rs, 0, offset)
 #define B(offset)		BEQ(0, 0, offset)
+
+#define BGEZ(rs, offset) \
+	write32(0x04010000 | ((rs) << 21) | ((offset) >> 2))
+
+#define BGTZ(rs, offset) \
+	write32(0x1c000000 | ((rs) << 21) | ((offset) >> 2))
+
+#define BLEZ(rs, offset) \
+	write32(0x18000000 | ((rs) << 21) | ((offset) >> 2))
+
+#define BLTZ(rs, offset) \
+	write32(0x04000000 | ((rs) << 21) | ((offset) >> 2))
 
 #define BNE(rs, rt, offset) \
 	write32(0x14000000 | (rs << 21) | (rt << 16) | (offset >> 2))
@@ -269,11 +287,11 @@ do { \
 	write32(0); /* nop */ \
 } while (0)
 
-/* call func */
+/* call func (JAL wrapper with NOP in BD slot) */
 #define CALLFunc(func) \
 do { \
-	write32(0x0c000000 | ((func & 0x0fffffff) >> 2)); /* jal func */ \
-	write32(0); /* nop */ \
+	JAL(func); \
+	NOP(); /* <BD> */ \
 } while (0)
 
 #define mips_relative_offset(source, offset, next) \

--- a/src/recompiler/mips/mips_codegen.h
+++ b/src/recompiler/mips/mips_codegen.h
@@ -29,6 +29,14 @@
 #ifndef MIPS_CG_H
 #define MIPS_CG_H
 
+// Mips32r2 introduced useful instructions:
+//TODO: Update all code that uses EXT/INS/SEB/SEH to use these guards.
+#if (defined(_MIPS_ARCH_MIPS32R2) || defined(_MIPS_ARCH_MIPS32R3) || \
+     defined(_MIPS_ARCH_MIPS32R5) || defined(_MIPS_ARCH_MIPS32R6))
+#define HAVE_MIPS32R2_EXT_INS
+#define HAVE_MIPS32R2_SEB_SEH
+#endif
+
 typedef enum {
 	MIPSREG_V0 = 2,
 	MIPSREG_V1,
@@ -220,6 +228,8 @@ do { \
 #define NOP() \
 	write32(0)
 
+
+#ifdef HAVE_MIPS32R2_EXT_INS
 #define EXT(rt, rs, pos, size) \
 	write32(0x7c000000 | (rs << 21) | (rt << 16) | \
 	        ((pos & 0x1f) << 6) | (((size-1) & 0x1f) << 11))
@@ -227,12 +237,17 @@ do { \
 #define INS(rt, rs, pos, size) \
 	write32(0x7c000004 | (rs << 21) | (rt << 16) | \
 	        ((pos & 0x1f) << 6) | (((pos+size-1) & 0x1f) << 11))
+#endif //HAVE_MIPS32R2_EXT_INS
 
+
+#ifdef HAVE_MIPS32R2_SEB_SEH
 #define SEB(rd, rt) \
 	write32(0x7C000420 | (rt << 16) | (rd << 11))
 
 #define SEH(rd, rt) \
 	write32(0x7C000620 | (rt << 16) | (rd << 11))
+#endif //HAVE_MIPS32R2_SEB_SEH
+
 
 #define CLZ(rd, rs) \
 	write32(0x70000020 | (rs << 21) | (rd << 16) | (rd << 11))

--- a/src/recompiler/mips/mips_codegen.h
+++ b/src/recompiler/mips/mips_codegen.h
@@ -65,6 +65,8 @@ typedef enum {
 	MIPSREG_S5,
 	MIPSREG_S6,
 	MIPSREG_S7,
+
+	MIPSREG_SP = 0x1d,
 } MIPSReg;
 
 #define TEMP_1 				MIPSREG_T0

--- a/src/recompiler/mips/rec_bcu.cpp.h
+++ b/src/recompiler/mips/rec_bcu.cpp.h
@@ -250,7 +250,7 @@ static void recBLTZ()
 	u32 br1 = regMipsToHost(_Rs_, REG_LOADBRANCH, REG_REGISTERBRANCH);
 	SetBranch();
 	u32 *backpatch = (u32*)recMem;
-	write32(0x04010000 | (br1 << 21)); /* bgez */
+	BGEZ(br1, 0);
 	// Use BD slot of branch above to load upper part of branch-taken PC val
 	LUI(TEMP_1, (bpc >> 16)); // <BD>
 
@@ -283,7 +283,7 @@ static void recBGTZ()
 	u32 br1 = regMipsToHost(_Rs_, REG_LOADBRANCH, REG_REGISTERBRANCH);
 	SetBranch();
 	u32 *backpatch = (u32*)recMem;
-	write32(0x18000000 | (br1 << 21)); /* blez */
+	BLEZ(br1, 0);
 	// Use BD slot of branch above to load upper part of branch-taken PC val
 	LUI(TEMP_1, (bpc >> 16)); // <BD>
 
@@ -316,7 +316,7 @@ static void recBLTZAL()
 	u32 br1 = regMipsToHost(_Rs_, REG_LOADBRANCH, REG_REGISTERBRANCH);
 	SetBranch();
 	u32 *backpatch = (u32*)recMem;
-	write32(0x04010000 | (br1 << 21)); /* bgez */
+	BGEZ(br1, 0);
 	// Use BD slot of branch above to load upper part of branch-taken PC val
 	LUI(TEMP_1, (bpc >> 16)); // <BD>
 
@@ -351,7 +351,7 @@ static void recBGEZAL()
 	u32 br1 = regMipsToHost(_Rs_, REG_LOADBRANCH, REG_REGISTERBRANCH);
 	SetBranch();
 	u32 *backpatch = (u32*)recMem;
-	write32(0x04000000 | (br1 << 21)); /* bltz */
+	BLTZ(br1, 0);
 	// Use BD slot of branch above to load upper part of branch-taken PC val
 	LUI(TEMP_1, (bpc >> 16)); // <BD>
 
@@ -438,7 +438,7 @@ static void recBEQ()
 	u32 br2 = regMipsToHost(_Rt_, REG_LOADBRANCH, REG_REGISTERBRANCH);
 	SetBranch();
 	u32 *backpatch = (u32*)recMem;
-	write32(0x14000000 | (br1 << 21) | (br2 << 16)); /* bne */
+	BNE(br1, br2, 0);
 	// Use BD slot of branch above to load upper part of branch-taken PC val
 	LUI(TEMP_1, (bpc >> 16)); // <BD>
 
@@ -472,7 +472,7 @@ static void recBNE()
 	u32 br2 = regMipsToHost(_Rt_, REG_LOADBRANCH, REG_REGISTERBRANCH);
 	SetBranch();
 	u32* backpatch = (u32*)recMem;
-	write32(0x10000000 | (br1 << 21) | (br2 << 16)); /* beq */
+	BEQ(br1, br2, 0);
 	// Use BD slot of branch above to load upper part of branch-taken PC val
 	LUI(TEMP_1, (bpc >> 16)); // <BD>
 
@@ -506,10 +506,10 @@ static void recBLEZ()
 	u32 br1 = regMipsToHost(_Rs_, REG_LOADBRANCH, REG_REGISTERBRANCH);
 	SetBranch();
 	u32 *backpatch = (u32*)recMem;
-	write32(0x1c000000 | (br1 << 21)); /* bgtz */
+	BGTZ(br1, 0);
 	// Use BD slot of branch above to load upper part of branch-taken PC val
-
 	LUI(TEMP_1, (bpc >> 16)); // <BD>
+
 	rec_recompile_end_part1();
 	regClearBranch();
 	ORI(MIPSREG_V0, TEMP_1, (bpc & 0xffff)); // Block retval $v0 = branch-taken PC val
@@ -539,7 +539,7 @@ static void recBGEZ()
 	u32 br1 = regMipsToHost(_Rs_, REG_LOADBRANCH, REG_REGISTERBRANCH);
 	SetBranch();
 	u32 *backpatch = (u32*)recMem;
-	write32(0x04000000 | (br1 << 21)); /* bltz */
+	BLTZ(br1, 0);
 	// Use BD slot of branch above to load upper part of branch-taken PC val
 	LUI(TEMP_1, (bpc >> 16)); // <BD>
 

--- a/src/recompiler/mips/rec_cp0.cpp.h
+++ b/src/recompiler/mips/rec_cp0.cpp.h
@@ -34,14 +34,27 @@ static void recCTC0()
 
 static void recRFE()
 {
-	write32(0x3c00ffff | (TEMP_2 << 16)); /* lui 0xffff */
-	write32(0x3400fff0 | (TEMP_2 << 21) | (TEMP_2 << 16)); /* ori 0xfff0 */
+// 'Return from exception' opcode
+//  Inside CP0 Status register (12), RFE atomically copies bits 5:2 to
+//  bits 3:0 , unwinding the exception 'stack'
 
 	LW(TEMP_1, PERM_REG_1, offCP0(12));
-	AND(TEMP_2, TEMP_1, TEMP_2);
-	write32(0x30000000 | (TEMP_1 << 21) | (TEMP_1 << 16) | 0x3c); /* andi t1, t1, 0x3c */
-	write32(0x00000002 | (TEMP_1 << 16) | (TEMP_1 << 11) | (2 << 6)); /* srl t1, t1, 2 */
-	write32(0x00000025 | (TEMP_2 << 21) | (TEMP_1 << 16) | (TEMP_1 << 11)); /* or t1, t2, t1 */
+
+	// Reset psxRegs.io_cycle_counter, so that psxBranchTest() is called as
+	//  soon as possible to handle any pending interrupts/events
+	SW(0, PERM_REG_1, off(io_cycle_counter));
+
+#ifdef HAVE_MIPS32R2_EXT_INS
+	EXT(TEMP_2, TEMP_1, 2, 4);   // Copy bits 5:2 of TEMP_1 to 3:0 of TEMP_2
+	INS(TEMP_1, TEMP_2, 0, 4);   // Copy those bits back to 3:0 of TEMP_1
+#else
+	SRL(TEMP_2, TEMP_1, 4);
+	SLL(TEMP_2, TEMP_2, 4);      // TEMP_2 = orig SR value with bits 3:0 cleared
+
+	ANDI(TEMP_1, TEMP_1, 0x3c);  // TEMP_1 = just bits 5:2 from orig SR value
+	SRL(TEMP_1, TEMP_1, 2);      // Shift them right two places
+	OR(TEMP_1, TEMP_2, TEMP_1);  // TEMP_1 = new SR value
+#endif
 
 	SW(TEMP_1, PERM_REG_1, offCP0(12));
 }

--- a/src/recompiler/mips/recompiler.cpp
+++ b/src/recompiler/mips/recompiler.cpp
@@ -223,7 +223,6 @@ static void recRecompile()
 	} while (!end_block);
 
 	end_block = 0;
-	rec_recompile_end();
 	DISASM_HOST();
 	clear_insn_cache(recMemStart, recMem, 0);
 }
@@ -269,14 +268,43 @@ static void recShutdown() { }
 static __attribute__ ((noinline)) void recFunc(void *fn)
 {
 	/* This magic code calls fn address saving registers $s[0-7], $fp and $ra. */
+	/*                                                                         */
+	/* Focus here is on clarity, not speed. This is the bare minimum needed to */
+	/*  call blocks from within C code, which is:                              */
+	/* Blocks expect $fp to be set to &psxRegs.                                */
+	/* Blocks expect return address to be stored at 16($sp).                   */
+	/* Stack should have 16 bytes free at 0($sp) for use by called functions.  */
+	/* Stack should be 8-byte aligned to satisfy MIPS ABI.                     */
+	/*                                                                         */
+	/* Blocks return these values, which are handled here:                     */
+	/*  $v0 is new value for psxRegs.pc                                        */
+	/*  $v1 is number of cycles to increment psxRegs.cycle by                  */
 	__asm__ __volatile__ (
-		"jalr   %0 \n"
-		:
-		: "r" (fn)
-		: "%s0", "%s1", "%s2", "%s3", "%s4", "%s5", "%s6", "%s7", "%fp", "%ra");
+		"addiu  $sp, $sp, -24                   \n"
+		"la     $fp, %[psxRegs]                 \n" // $fp = &psxRegs
+		"la     $t0, block_return_addr%=        \n"
+		"sw     $t0, 16($sp)                    \n" // Put 'block_return_addr' on stack
+		"jr     %[fn]                           \n" // Execute block
+
+		"block_return_addr%=:                   \n"
+		"sw     $v0, %[psxRegs_pc_off]($fp)     \n" // psxRegs.pc = $v0
+		"lw     $t1, %[psxRegs_cycle_off]($fp)  \n" //
+		"addu   $t1, $t1, $v1                   \n" //
+		"sw     $t1, %[psxRegs_cycle_off]($fp)  \n" // psxRegs.cycle += $v1
+		"addiu  $sp, $sp, 24                    \n"
+		: // Output
+		: // Input
+		  [fn]                   "r" (fn),
+		  [psxRegs]              "i" (&psxRegs),
+		  [psxRegs_pc_off]       "i" (off(pc)),   // Offset of psxRegs.pc in psxRegs
+		  [psxRegs_cycle_off]    "i" (off(cycle)) // Offset of psxRegs.cycle in psxRegs
+		: // Clobber - No need to list anything but 'saved' regs
+		  "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "fp", "ra", "memory"
+	);
 }
 #endif
 
+/* Execute blocks starting at psxRegs.pc */
 static void recExecute()
 {
 #ifndef ASM_EXECUTE_LOOP
@@ -286,15 +314,17 @@ static void recExecute()
 			recRecompile();
 
 		recFunc((void *)*p);
+
+		if (psxRegs.cycle >= psxRegs.io_cycle_counter)
+			psxBranchTest();
 	}
 #else
 __asm__ __volatile__ (
 // NOTE: <BD> indicates an instruction in a branch-delay slot
 ".set noreorder                               \n"
 
-// $fp/$s8 remains set to &psxRegs across all calls to dynarec blocks
-"lui    $fp,      %%hi(%[psxRegs])            \n"
-"addiu  $fp, $fp, %%lo(%[psxRegs])            \n"
+// $fp/$s8 remains set to &psxRegs across all calls to blocks
+"la    $fp, %[psxRegs]                        \n"
 
 // Set up our own stack frame. Should have 8-byte alignment, and have 16 bytes
 // empty at 0($sp) for use by functions called from within recompiled code.
@@ -304,70 +334,126 @@ __asm__ __volatile__ (
 "addiu $sp, $sp, -frame_size                  \n"
 
 // Store const block return address at fixed location in stack frame
-"lui   $t0,      %%hi(return_from_block%=)    \n"
-"addiu $t0, $t0, %%lo(return_from_block%=)    \n"
+"la    $t0, loop%=                            \n"
 "sw    $t0, f_off_block_ret_addr($sp)         \n"
 
-// Load $v0 once with psxRegs.pc, it will be set to new
-//  value at end of each loop
-"lw    $v0, %[psxRegs_pc_off]($fp)            \n" // $v0 = psxRegs.pc
+// Load $v0 once with psxRegs.pc, blocks will assign new value when returning
+"lw    $v0, %[psxRegs_pc_off]($fp)            \n"
+
+// Load $v1 once with zero. It is the # of cycles psxRegs.cycle should be
+// incremented by when a block returns.
+"move  $v1, $0                                \n"
 
 // Align loop on cache-line boundary
 ".balign 32, 0, 31                            \n"
 
-// Infinite loop:
-"loop%=:                                      \n"
+////////////////////////////
+//       LOOP CODE:       //
+////////////////////////////
 
-// NOTE: End of loop will have set $v0 to psxRegs.pc
+// NOTE: Loop expects following values to be set:
+// $v0 = new value for psxRegs.pc
+// $v1 = # of cycles to increment psxRegs.cycle by
+
+// The loop pseudocode is this, interleaving ops to reduce load stalls:
+//
+// loop:
 // $t2 = psxRecLUT[pxsRegs.pc >> 16] + (psxRegs.pc & 0xffff)
 // $t0 = *($t2)
+// psxRegs.cycle += $v1
+// if (psxRegs.cycle >= psxRegs.io_cycle_counter)
+//    goto call_psxBranchTest;
+// psxRegs.pc = $v0
+// if ($t0 == 0)
+//    goto recompile_block;
+// goto $t0;
+// /* Code at addr $t0 will run and return having set $v0 to new psxRegs.pc */
+// /*  value and $v1 to the number of cycles to increment psxRegs.cycle by. */
+// goto loop;
+
+// Infinite loop, blocks return here
+"loop%=:                                      \n"
+"lw    $t3, %[psxRegs_cycle_off]($fp)         \n" // $t3 = psxRegs.cycle
 "lui   $t1, %%hi(%[psxRecLUT])                \n"
 "srl   $t2, $v0, 16                           \n"
-"sll   $t2, $t2, 2                            \n"
+"sll   $t2, $t2, 2                            \n" // sizeof() psxRecLUT[] elements is 4
 "addu  $t1, $t1, $t2                          \n"
-"lw    $t1, %%lo(%[psxRecLUT])($t1)           \n"
-"andi  $v0, $v0, 0xffff                       \n"
-"addu  $t2, $v0, $t1                          \n"
-"lw    $t0, 0($t2)                            \n"
+"lw    $t1, %%lo(%[psxRecLUT])($t1)           \n" // $t1 = psxRecLUT[psxRegs.pc >> 16]
+"lw    $t4, %[psxRegs_io_cycle_ctr_off]($fp)  \n" // $t4 = psxRegs.io_cycle_counter
+"addu  $t3, $t3, $v1                          \n" // $t3 = psxRegs.cycle + $v1
+"andi  $t0, $v0, 0xffff                       \n"
+"addu  $t2, $t0, $t1                          \n" // 1-cycle load stall on $t1 here
+"lw    $t0, 0($t2)                            \n" // $t0 now points to beginning of recompiled
+                                                  //  block, or is 0 if block needs recompiling
+
+// Must call psxBranchTest() when psxRegs.cycle >= psxRegs.io_cycle_counter
+"sltu  $t4, $t3, $t4                          \n"
+"beqz  $t4, call_psxBranchTest%=              \n"
+"sw    $t3, %[psxRegs_cycle_off]($fp)         \n" // <BD> IMPORTANT: store new psxRegs.cycle val,
+                                                  //  whether or not we are branching here
 
 // Recompile block, if necessary
-"beqz  $t0, recompile_block%=                 \n"
-"nop                                          \n" // <BD>
+"recompile_block_check%=:                     \n"
+"beqz  $t0, recompile_block%=                 \n" // 1-cycle load stall on $t0 here
+"sw    $v0, %[psxRegs_pc_off]($fp)            \n" // <BD> Use BD slot to store new psxRegs.pc val
 
-// Execute already-compiled block
+// Execute already-compiled block. It will return at top of loop.
 "execute_block%=:                             \n"
 "jr    $t0                                    \n"
 "nop                                          \n" // <BD>
 
-// Return point for all executed blocks
-"return_from_block%=:                         \n"
-"b     loop%=                                 \n" // Loop, loading PC in BD slot
-"lw    $v0, %[psxRegs_pc_off]($fp)            \n" // <BD>  $v0 = psxRegs.pc
+////////////////////////////
+//     NON-LOOP CODE:     //
+////////////////////////////
 
-// Recompile block and execute it. It will return to label 'return_from_block'
+// Recompile block and return to normal codepath.
 "recompile_block%=:                           \n"
 "jal   %[recRecompile]                        \n"
-"sw    $t2, f_off_temp_var1($sp)              \n" // <BD> Save block ptr
-"lw    $t2, f_off_temp_var1($sp)              \n" // Restore block ptr
-"lw    $t0, 0($t2)                            \n"
-"jr    $t0                                    \n" // Execute block
-"nop                                          \n" // <BD>
+"sw    $t2, f_off_temp_var1($sp)              \n" // <BD> Save block ptr across call
+"lw    $t2, f_off_temp_var1($sp)              \n" // Restore block ptr upon return
+"b     execute_block%=                        \n" // Resume normal code path, but first we must..
+"lw    $t0, 0($t2)                            \n" // <BD> ..load $t0 with ptr to block code
 
-// Destroy stack frame (we'd never actually reach here)
+// Call psxBranchTest() and go back to top of loop
+"call_psxBranchTest%=:                        \n"
+"jal   %[psxBranchTest]                       \n"
+"sw    $v0, %[psxRegs_pc_off]($fp)            \n" // <BD> Use BD slot to store new psxRegs.pc val,
+                                                  //  as psxBranchTest() might issue an exception.
+"lw    $v0, %[psxRegs_pc_off]($fp)            \n" // After psxBranchTest() returns, load psxRegs.pc
+                                                  //  back into $v0, which could be different than
+                                                  //  before the call if an exception was issued.
+"b     loop%=                                 \n" // Go back to top to process psxRegs.pc again..
+"move  $v1, $0                                \n" // <BD> ..using BD slot to set $v1 to 0, since
+                                                  //  psxRegs.cycle shouldn't be incremented again.
+
+// Destroy stack frame, exiting inlined ASM block
+// NOTE: We'd never reach this point because the block dispatch loop is
+//  currently infinite. This could change in the future.
+// TODO: Could add a way to reset a game or load a new game from within
+//  the running emulator by setting a global boolean, resetting
+//  psxRegs.io_cycle_counter to 0, and checking if it's been set before
+//  calling pxsBranchTest() here. If set, you must jump here to
+//  exit the loop, to ensure that stack frame is adjusted before return!
+"exit%=:                                      \n"
 "addiu $sp, $sp, frame_size                   \n"
 ".set reorder                                 \n"
 
 : // Output
 : // Input
-     [psxRegs]                    "i" (&psxRegs),
-     [psxRegs_pc_off]             "i" (off(pc)),
-     [psxRecLUT]                  "i" (&psxRecLUT),
-     [recRecompile]               "i" (&recRecompile)
-: // Clobber - Don't care, the ASM loop above is infinite
+  [psxRegs]                    "i" (&psxRegs),
+  [psxRegs_pc_off]             "i" (off(pc)),
+  [psxRegs_cycle_off]          "i" (off(cycle)),
+  [psxRegs_io_cycle_ctr_off]   "i" (off(io_cycle_counter)),
+  [psxRecLUT]                  "i" (&psxRecLUT),
+  [recRecompile]               "i" (&recRecompile),
+  [psxBranchTest]              "i" (&psxBranchTest)
+: // Clobber - No need to list anything but 'saved' regs
+  "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "fp", "ra", "memory"
 );
 #endif
 }
 
+/* Execute blocks starting at psxRegs.pc until target_pc is reached */
 static void recExecuteBlock(unsigned target_pc)
 {
 #ifndef ASM_EXECUTE_LOOP
@@ -377,93 +463,142 @@ static void recExecuteBlock(unsigned target_pc)
 			recRecompile();
 
 		recFunc((void *)*p);
+
+		if (psxRegs.cycle >= psxRegs.io_cycle_counter)
+			psxBranchTest();
 	} while (psxRegs.pc != target_pc);
 #else
 __asm__ __volatile__ (
 // NOTE: <BD> indicates an instruction in a branch-delay slot
 ".set noreorder                               \n"
 
-// $fp/$s8 remains set to &psxRegs across all calls to dynarec blocks
-"lui   $fp,      %%hi(%[psxRegs])             \n"
-"addiu $fp, $fp, %%lo(%[psxRegs])             \n"
+// $fp/$s8 remains set to &psxRegs across all calls to blocks
+"la     $fp, %[psxRegs]                       \n"
 
 // Set up our own stack frame. Should have 8-byte alignment, and have 16 bytes
 // empty at 0($sp) for use by functions called from within recompiled code.
 ".equ  frame_size,                  32        \n"
-".equ  f_off_orig_gp_regval,        28        \n"
 ".equ  f_off_target_pc,             24        \n"
 ".equ  f_off_temp_var1,             20        \n"
 ".equ  f_off_block_ret_addr,        16        \n" // NOTE: blocks assume this is at 16($sp)!
 "addiu $sp, $sp, -frame_size                  \n"
 
-// Save original $gp val. GCC requires inline ASM to do this manually.
-"sw    $gp, f_off_orig_gp_regval($sp)         \n"
-
 // Store const copy of 'target_pc' parameter in stack frame
 "sw    %[target_pc], f_off_target_pc($sp)     \n"
 
 // Store const block return address at fixed location in stack frame
-"lui   $t0,      %%hi(return_from_block%=)    \n"
-"addiu $t0, $t0, %%lo(return_from_block%=)    \n"
+"la    $t0, return_from_block%=               \n"
 "sw    $t0, f_off_block_ret_addr($sp)         \n"
 
-// Load $v0 once with psxRegs.pc, it will be set to new
-//  value at end of each loop
+// Load $v0 once with psxRegs.pc, blocks will assign new value when returning
 "lw    $v0, %[psxRegs_pc_off]($fp)            \n"
 
-// Load $t1 once with upper base addr of psxRecLUT[],
-//  it will be loaded again at end of each loop
-"lui   $t1, %%hi(%[psxRecLUT])                \n"
+// Load $v1 once with zero. It is the # of cycles psxRegs.cycle should be
+// incremented by when a block returns.
+"move  $v1, $0                                \n"
 
 // Align loop on cache-line boundary
 ".balign 32, 0, 31                            \n"
 
-// Loop until psxRegs.pc == target_pc
-"loop%=:                                      \n"
-// NOTE: End of loop will have set $t1 to %%hi(%[psxRecLUT])
-//       and $v0 to psxRegs.pc
+////////////////////////////
+//       LOOP CODE:       //
+////////////////////////////
+
+// NOTE: Loop expects following values to be set:
+// $v0 = new value for psxRegs.pc
+// $v1 = # of cycles to increment psxRegs.cycle by
+
+// The loop pseudocode is this, interleaving ops to reduce load stalls:
+//
+// loop:
 // $t2 = psxRecLUT[pxsRegs.pc >> 16] + (psxRegs.pc & 0xffff)
 // $t0 = *($t2)
+// psxRegs.cycle += $v1
+// if (psxRegs.cycle >= psxRegs.io_cycle_counter)
+//    goto call_psxBranchTest;
+// if ($t0 == 0)
+//    goto recompile_block;
+// goto $t0;
+// /* Code at addr $t0 will run and return having set $v0 to new psxRegs.pc */
+// /*  value and $v1 to the number of cycles to increment psxRegs.cycle by. */
+// psxRegs.pc = $v0
+// if (psxRegs.pc == target_pc)
+//    goto exit;
+// else
+//    goto loop;
+
+// Loop until psxRegs.pc == target_pc
+"loop%=:                                      \n"
+"lw    $t3, %[psxRegs_cycle_off]($fp)         \n" // $t3 = psxRegs.cycle
+"lui   $t1, %%hi(%[psxRecLUT])                \n"
 "srl   $t2, $v0, 16                           \n"
-"sll   $t2, $t2, 2                            \n"
+"sll   $t2, $t2, 2                            \n" // sizeof() psxRecLUT[] elements is 4
 "addu  $t1, $t1, $t2                          \n"
-"lw    $t1, %%lo(%[psxRecLUT])($t1)           \n"
-"andi  $v0, $v0, 0xffff                       \n"
-"addu  $t2, $v0, $t1                          \n"
-"lw    $t0, 0($t2)                            \n"
+"lw    $t1, %%lo(%[psxRecLUT])($t1)           \n" // $t1 = psxRecLUT[psxRegs.pc >> 16]
+"lw    $t4, %[psxRegs_io_cycle_ctr_off]($fp)  \n" // $t4 = psxRegs.io_cycle_counter
+"addu  $t3, $t3, $v1                          \n" // $t3 = new psxRegs.cycle val
+"andi  $t0, $v0, 0xffff                       \n"
+"addu  $t2, $t0, $t1                          \n" // 1-cycle load stall on $t1 here
+"lw    $t0, 0($t2)                            \n" // $t0 now points to beginning of recompiled
+                                                  //  block, or is 0 if block needs compiling
+
+// Must call psxBranchTest() when psxRegs.cycle >= psxRegs.io_cycle_counter
+"sltu  $t4, $t3, $t4                          \n"
+"beqz  $t4, call_psxBranchTest%=              \n"
+"sw    $t3, %[psxRegs_cycle_off]($fp)         \n" // <BD> IMPORTANT: store new psxRegs.cycle val,
+                                                  //  whether or not we are branching here
 
 // Recompile block, if necessary
-"beqz  $t0, recompile_block%=                 \n"
+"recompile_block_check%=:                     \n"
+"beqz  $t0, recompile_block%=                 \n" // 1-cycle load stall on $t0 here
 "nop                                          \n" // <BD>
 
-// Execute already-compiled block
+// Execute already-compiled block.
 "execute_block%=:                             \n"
 "jr    $t0                                    \n"
 "nop                                          \n" // <BD>
 
-// Return point for all executed blocks
 "return_from_block%=:                         \n"
+// Return point for all executed blocks, which will have set:
+// $v0 to new value for psxRegs.pc
+// $v1 to the # of cycles to increment psxRegs.cycle by
+
 // Check if target_pc has been reached, looping if not
-"lw    $v0, %[psxRegs_pc_off]($fp)            \n" // $v0 = psxRegs.pc
 "lw    $t0, f_off_target_pc($sp)              \n" // $t0 = target_pc
-"bne   $v0, $t0, loop%=                       \n" // loop if psxRegs.pc != target_pc
-"lui   $t1, %%hi(%[psxRecLUT])                \n" // <BD> Top of loop needs this
+"bne   $v0, $t0, loop%=                       \n" // Loop if target_pc hasn't been reached, using..
+"sw    $v0, %[psxRegs_pc_off]($fp)            \n" // <BD> ..BD slot to store new psxRegs.pc val
 
-// Since target_pc has been reached, goto 'end_label'
-"b     end_label%=                            \n"
-"lw    $gp, f_off_orig_gp_regval($sp)         \n" // <BD> Restore $gp reg in BD slot
+// Before cleanup/exit, ensure psxRegs.cycle is incremented by block's $v1 retval
+"lw    $t3, %[psxRegs_cycle_off]($fp)         \n" // $t3 = psxRegs.cycle
+"addu  $t3, $t3, $v1                          \n"
+"b     exit%=                                 \n" // Goto cleanup/exit code, using BD slot..
+"sw    $t3, %[psxRegs_cycle_off]($fp)         \n" // <BD> ..to store new psxRegs.cycle val
 
-// Recompile block and execute it. It will return to label 'return_from_block'
+////////////////////////////
+//     NON-LOOP CODE:     //
+////////////////////////////
+
+// Recompile block and return to normal codepath
 "recompile_block%=:                           \n"
 "jal   %[recRecompile]                        \n"
-"sw    $t2, f_off_temp_var1($sp)              \n" // <BD> Save block code ptr on stack
-"lw    $t2, f_off_temp_var1($sp)              \n" // Restore block code ptr from stack
-"lw    $t0, 0($t2)                            \n"
-"jr    $t0                                    \n" // Execute block
+"sw    $t2, f_off_temp_var1($sp)              \n" // <BD> Save block ptr across call
+"lw    $t2, f_off_temp_var1($sp)              \n" // Restore block ptr upon return
+"b     execute_block%=                        \n" // Resume normal code path, but first we must..
+"lw    $t0, 0($t2)                            \n" // <BD> ..load $t0 with ptr to block code
+
+// Call psxBranchTest() and go back to top of loop
+"call_psxBranchTest%=:                        \n"
+"jal   %[psxBranchTest]                       \n"
 "nop                                          \n" // <BD>
+"lw    $v0, %[psxRegs_pc_off]($fp)            \n" // After psxBranchTest() returns, load psxRegs.pc
+                                                  //  back into $v0, which could be different than
+                                                  //  before the call if an exception was issued.
+"b     loop%=                                 \n" // Go back to top to process psxRegs.pc again..
+"move  $v1, $0                                \n" // <BD> ..using BD slot to set $v1 to 0, since
+                                                  //  psxRegs.cycle shouldn't be incremented again.
 
 // Destroy stack frame, exiting inlined ASM block
-"end_label%=:                                 \n"
+"exit%=:                                      \n"
 "addiu $sp, $sp, frame_size                   \n"
 ".set reorder                                 \n"
 
@@ -472,13 +607,13 @@ __asm__ __volatile__ (
   [target_pc]                  "r" (target_pc),
   [psxRegs]                    "i" (&psxRegs),
   [psxRegs_pc_off]             "i" (off(pc)),
+  [psxRegs_cycle_off]          "i" (off(cycle)),
+  [psxRegs_io_cycle_ctr_off]   "i" (off(io_cycle_counter)),
   [psxRecLUT]                  "i" (&psxRecLUT),
-  [recRecompile]               "i" (&recRecompile)
-: // Clobber
-  "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9",
-  "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7",
-  "v0", "v1", "at", "fp", "ra",
-  "memory"
+  [recRecompile]               "i" (&recRecompile),
+  [psxBranchTest]              "i" (&psxBranchTest)
+: // Clobber - No need to list anything but 'saved' regs
+  "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "fp", "ra", "memory"
 );
 #endif
 }

--- a/src/sio.cpp
+++ b/src/sio.cpp
@@ -381,6 +381,7 @@ unsigned short sioReadBaud16() {
 #endif
 	return BaudReg;
 }
+
 void sioInterrupt() {
 #ifdef DEBUG_ANALYSIS
 	dbg_anacnt_sioInterrupt++;
@@ -393,9 +394,9 @@ void sioInterrupt() {
 	if (!(StatReg & IRQ)) {
 		StatReg |= IRQ;
 		psxHu32ref(0x1070) |= SWAPu32(0x80);
+		// Ensure psxBranchTest() is called soon when IRQ is pending:
+		ResetIoCycle();
 	}
-	// CHUI: Añado ResetIoCycle para permite que en el proximo salto entre en psxBranchTest
-	ResetIoCycle();
 }
 
 void LoadMcd(int mcd, char *str) {


### PR DESCRIPTION
10-20% overall performance improvement on GCW Zero, depending on game.

- Compatiblity maintained with older savestates, no loss in game compatibility.
- Added new event/interrupt scheduler queue (psxevents.cpp, psxevents.h) efficiently sorts scheduled events based on their imminency upon insertion.
- Queue allows psxBranchTest() to be greatly simplified and centralizes handling of scheduling events from elsewhere in the code
- psxRegs.io_cycle_counter now accurately can be used to determine when next call to psxBranchTest() is needed, by seeing if psxRegs.cycle is >= to it.  By doing this now, the number of times psxBranchTest() is called per frame is reduced from an average of 15,000 to less than 50, often less, a reduction of over 99%.
- New event type PSXINT_RESET_CYCLE_VAL resets psxRegs.cycle to 0 every 2 billion emulated cycles, ensuring it never overflows. At the same time, root counter timestamps are also adjusted accordingly. This ensures comparison between psxRegs.cycle and psxRegs.io_cycle_counter is always accurate.
- MIPS dynarec block dispatch/entry/exit code is optimized heavily, factoring out code common to all blocks into main dispatch loop. Dispatch loop itself is optimized/commented and avoids load stalls.
- Recompiled MIPS blocks now return new psxRegs.pc value in $v0 and # of cycles ot increment psxRegs.cycle by in $v1. This allows main dispatch loop to handle the usage/updating of values.
- Misc dynarec improvements like added missing branch/jump macros, eliminated writing raw opcodes, make use of branch delay slot when calling functions from within recompiled code.
- GCW Zero builds are built with options '-mplt -mno-shared', which makes calling functions from within inline MIPS ASM easier/predictable (don't need to worry about assigning/saving $gp reg when calling, also reduces size of overall binary since $25 doesn't need to be set and $28 setup every time function is called). It also keeps GCC from bitching about not using .frame and .cprestore inside an inline ASM block when '.set noreorder' is enabled.