### PR TITLE
Error checking, savestate, and memcard work

### DIFF
--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -34,9 +34,8 @@ MCD1_FILE = \"mcd001.mcr\"
 MCD2_FILE = \"mcd002.mcr\"
 
 CFLAGS = -mips32r2 -mplt -mno-shared -ggdb3 -O2 -DGCW_ZERO \
-	 -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align \
-	 -Wno-unused-value -Wno-write-strings -Wno-narrowing \
-	 -Waggregate-return -Wno-cast-align \
+	-Wall -Wunused -Wpointer-arith \
+	-Wno-sign-compare -Wno-cast-align \
 	-Isrc -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) \
 	-D$(GPU) -Isrc/port/$(PORT) \
 	-Isrc/gte/$(GTE) -D$(INTERPRETER) -D$(GTE) \

--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -37,7 +37,7 @@ CFLAGS = -mips32r2 -mplt -mno-shared -ggdb3 -O2 -DGCW_ZERO \
 	 -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align \
 	 -Wno-unused-value -Wno-write-strings -Wno-narrowing \
 	 -Waggregate-return -Wno-cast-align \
-	-Isrc -Isrc/zlib -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) \
+	-Isrc -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) \
 	-D$(GPU) -Isrc/port/$(PORT) \
 	-Isrc/gte/$(GTE) -D$(INTERPRETER) -D$(GTE) \
 	-DXA_HACK -DBIOS_FILE=$(BIOS_FILE) -DMCD1_FILE=$(MCD1_FILE) \
@@ -63,12 +63,12 @@ endif
 #CFLAGS += -DAUTOEVENTS
 #CFLAGS += -DAUTOEVENTS_MAX=8000
 
-LDFLAGS = $(SDL_LIBS) -lSDL_mixer -lSDL_image -lrt
+LDFLAGS = $(SDL_LIBS) -lSDL_mixer -lSDL_image -lrt -lz
 
 OBJDIRS = obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) \
 	  obj/interpreter obj/interpreter/$(INTERPRETER) \
 	  obj/recompiler obj/recompiler/$(RECOMPILER) \
-	  obj/zlib obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE)
+	  obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE)
 
 all: maketree $(TARGET)
 
@@ -89,13 +89,6 @@ endif
 OBJS += obj/gte/$(GTE)/gte.o
 OBJS += obj/gpu/$(GPU)/gpu.o
 OBJS += obj/spu/$(SPU)/spu.o
-
-OBJS += \
-	obj/zlib/adler32.o obj/zlib/compress.o obj/zlib/crc32.o \
-	obj/zlib/gzio.o obj/zlib/uncompr.o obj/zlib/deflate.o \
-	obj/zlib/trees.o obj/zlib/zutil.o obj/zlib/inflate.o \
-	obj/zlib/infblock.o obj/zlib/infcodes.o obj/zlib/inftrees.o \
-	obj/zlib/inffast.o obj/zlib/infutil.o
 
 OBJS += obj/port/$(PORT)/port.o
 OBJS += obj/port/$(PORT)/frontend.o

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -34,9 +34,8 @@ MCD1_FILE = \"mcd001.mcr\"
 MCD2_FILE = \"mcd002.mcr\"
 
 CFLAGS = -ggdb3 -O2 -march=native -DGCW_ZERO \
-	-Wall -Wno-sign-compare -Wunused -Wpointer-arith \
-	-Wno-unused-value -Wno-write-strings -Wno-narrowing \
-	-Waggregate-return -Wno-cast-align \
+	-Wall -Wunused -Wpointer-arith \
+	-Wno-sign-compare -Wno-cast-align \
 	-Isrc -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) \
 	-D$(GPU) -Isrc/port/$(PORT) \
 	-Isrc/gte/$(GTE) -D$(INTERPRETER) -D$(GTE) \

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -37,7 +37,7 @@ CFLAGS = -ggdb3 -O2 -march=native -DGCW_ZERO \
 	-Wall -Wno-sign-compare -Wunused -Wpointer-arith \
 	-Wno-unused-value -Wno-write-strings -Wno-narrowing \
 	-Waggregate-return -Wno-cast-align \
-	-Isrc -Isrc/zlib -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) \
+	-Isrc -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) \
 	-D$(GPU) -Isrc/port/$(PORT) \
 	-Isrc/gte/$(GTE) -D$(INTERPRETER) -D$(GTE) \
 	-DXA_HACK -DBIOS_FILE=$(BIOS_FILE) -DMCD1_FILE=$(MCD1_FILE) \
@@ -59,12 +59,12 @@ CFLAGS = -ggdb3 -O2 -march=native -DGCW_ZERO \
 #CFLAGS += -DAUTOEVENTS
 #CFLAGS += -DAUTOEVENTS_MAX=8000
 
-LDFLAGS = $(SDL_LIBS) -lSDL_mixer -lSDL_image -lpthread
+LDFLAGS = $(SDL_LIBS) -lSDL_mixer -lSDL_image -lpthread -lz
 
 OBJDIRS = \
 	obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) \
 	obj/interpreter obj/interpreter/$(INTERPRETER) \
-	obj/zlib obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE)
+	obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE)
 
 all: maketree $(TARGET)
 
@@ -79,13 +79,6 @@ OBJS = \
 OBJS += obj/gte/$(GTE)/gte.o
 OBJS += obj/gpu/$(GPU)/gpu.o
 OBJS += obj/spu/$(SPU)/spu.o
-
-OBJS += \
-	obj/zlib/adler32.o obj/zlib/compress.o obj/zlib/crc32.o \
-	obj/zlib/gzio.o obj/zlib/uncompr.o obj/zlib/deflate.o \
-	obj/zlib/trees.o obj/zlib/zutil.o obj/zlib/inflate.o \
-	obj/zlib/infblock.o obj/zlib/infcodes.o obj/zlib/inftrees.o \
-	obj/zlib/inffast.o obj/zlib/infutil.o
 
 OBJS += obj/port/$(PORT)/port.o
 OBJS += obj/port/$(PORT)/frontend.o

--- a/Makefile.win32
+++ b/Makefile.win32
@@ -32,9 +32,8 @@ MCD1_FILE = \"mcd001.mcr\"
 MCD2_FILE = \"mcd002.mcr\"
 
 CFLAGS = -ggdb3 -O2 -march=i686 -DGCW_ZERO \
-	-Wall -Wno-sign-compare -Wunused -Wpointer-arith \
-	-Wno-unused-value -Wno-write-strings -Wno-narrowing \
-	-Waggregate-return -Wno-cast-align \
+	-Wall -Wunused -Wpointer-arith \
+	-Wno-sign-compare -Wno-cast-align \
 	-Isrc -Isrc/zlib -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) \
 	-D$(GPU) -Isrc/port/$(PORT) \
 	-Isrc/gte/$(GTE) -D$(INTERPRETER) -D$(GTE) \

--- a/src/cdriso.cpp
+++ b/src/cdriso.cpp
@@ -1385,7 +1385,7 @@ static int cdread_compressed(FILE *f, unsigned int base, void *dest, int sector)
 
 	if (fread(is_compressed ? compr_img->buff_compressed : compr_img->buff_raw[0],
 				1, size, cdHandle) != size) {
-		printf("read error for block %d at %x: ", block, start_byte);
+		printf("read error for block %d at %lx: ", block, start_byte);
 		perror(NULL);
 		return -1;
 	}

--- a/src/cdriso.cpp
+++ b/src/cdriso.cpp
@@ -1390,11 +1390,15 @@ static int cdread_sub_mixed(FILE *f, unsigned int base, void *dest, int sector)
 {
 	int ret;
 
-	fseek(f, base + sector * (CD_FRAMESIZE_RAW + SUB_FRAMESIZE), SEEK_SET);
+	if (fseek(f, base + sector * (CD_FRAMESIZE_RAW + SUB_FRAMESIZE), SEEK_SET) == -1)
+		return -1;
 	ret = fread(dest, 1, CD_FRAMESIZE_RAW, f);
-	fread(subbuffer, 1, SUB_FRAMESIZE, f);
 
-	if (subChanRaw) DecodeRawSubData();
+	if (fread(subbuffer, 1, SUB_FRAMESIZE, f) != SUB_FRAMESIZE) {
+		printf("Error reading mixed subchannel info in cdread_sub_mixed()\n");
+	} else {
+		if (subChanRaw) DecodeRawSubData();
+	}
 
 	return ret;
 }

--- a/src/cdriso.cpp
+++ b/src/cdriso.cpp
@@ -1381,7 +1381,8 @@ static int opensbifile(const char *isoname) {
 
 static int cdread_normal(FILE *f, unsigned int base, void *dest, int sector)
 {
-	fseek(f, base + sector * CD_FRAMESIZE_RAW, SEEK_SET);
+	if (fseek(f, base + sector * CD_FRAMESIZE_RAW, SEEK_SET) == -1)
+		return -1;
 	return fread(dest, 1, CD_FRAMESIZE_RAW, f);
 }
 

--- a/src/cdriso.cpp
+++ b/src/cdriso.cpp
@@ -874,8 +874,7 @@ static int parseccd(const char *isofile) {
 	ccdname[MAXPATHLEN - 1] = '\0';
 	if (strlen(ccdname) >= 4) {
 		strcpy(ccdname + strlen(ccdname) - 4, ".ccd");
-	}
-	else {
+	} else {
 		return -1;
 	}
 
@@ -906,7 +905,8 @@ static int parseccd(const char *isofile) {
 		}
 	}
 
-	fclose(fi);
+	if (numtracks <= 0)
+		goto error;
 
 	// Fill out the last track's end based on size
 	if (numtracks >= 1) {
@@ -915,7 +915,13 @@ static int parseccd(const char *isofile) {
 		sec2msf(t, ti[numtracks].length);
 	}
 
+	fclose(fi);
 	return 0;
+
+error:
+	printf("\nError reading .CCD file %s\n", ccdname);
+	fclose(fi);
+	return -1;
 }
 
 // this function tries to get the .mds file of the given .mdf

--- a/src/cdriso.cpp
+++ b/src/cdriso.cpp
@@ -1508,7 +1508,9 @@ static int cdread_2048(FILE *f, unsigned int base, void *dest, int sector)
 {
 	int ret;
 
-	fseek(f, base + sector * 2048, SEEK_SET);
+	if (fseek(f, base + sector * 2048, SEEK_SET) == -1)
+		return -1;
+
 	ret = fread((char *)dest + 12 * 2, 1, 2048, f);
 
 	// not really necessary, fake mode 2 header

--- a/src/cdrom.h
+++ b/src/cdrom.h
@@ -127,7 +127,7 @@ void cdrWrite0(unsigned char rt);
 void cdrWrite1(unsigned char rt);
 void cdrWrite2(unsigned char rt);
 void cdrWrite3(unsigned char rt);
-int cdrFreeze(void *f, int Mode);
+int cdrFreeze(void *f, FreezeMode mode);
 
 u16 calcCrc(const u8 *d, const int len);
 

--- a/src/decode_xa.cpp
+++ b/src/decode_xa.cpp
@@ -52,17 +52,17 @@ static double K1[4] = {
 };
 #else
 static int K0[4] = {
-	0.0       * (1<<SHC),
-	0.9375    * (1<<SHC),
-	1.796875  * (1<<SHC),
-	1.53125   * (1<<SHC)
+	(int)(0.0       * (double)(1<<SHC)),
+	(int)(0.9375    * (double)(1<<SHC)),
+	(int)(1.796875  * (double)(1<<SHC)),
+	(int)(1.53125   * (double)(1<<SHC))
 };
  
 static int K1[4] = {
-	0.0       * (1<<SHC),
-	0.0       * (1<<SHC),
-	-0.8125   * (1<<SHC),
-	-0.859375 * (1<<SHC)
+	(int)(0.0       * (double)(1<<SHC)),
+	(int)(0.0       * (double)(1<<SHC)),
+	(int)(-0.8125   * (double)(1<<SHC)),
+	(int)(-0.859375 * (double)(1<<SHC))
 };
 #endif
 

--- a/src/gpu/gpu_unai/gpu_inner.h
+++ b/src/gpu/gpu_unai/gpu_inner.h
@@ -337,7 +337,7 @@ static void gpuPolySpanFn(u16 *pDst, u32 count)
 				do
 				{
 					// blit-mask
-					if (BI) { if((bMsk>>((((u32)pDst)>>1)&7))&1) goto endtile; }
+					if (BI) { if((bMsk>>((((uintptr_t)pDst)>>1)&7))&1) goto endtile; }
 					//  masking
 					uDst = *pDst;
 					if(M) { if (uDst&0x8000) goto endtile;  }
@@ -371,7 +371,7 @@ static void gpuPolySpanFn(u16 *pDst, u32 count)
 			do
 			{
 				// blit-mask
-				if (BI) { if((bMsk>>((((u32)pDst)>>1)&7))&1) goto endgou; }
+				if (BI) { if((bMsk>>((((uintptr_t)pDst)>>1)&7))&1) goto endgou; }
 				//  masking
 				if(M) { uDst = *pDst;  if (uDst&0x8000) goto endgou;  }
 				//  blend
@@ -440,7 +440,7 @@ static void gpuPolySpanFn(u16 *pDst, u32 count)
 		do
 		{
 			// blit-mask
-			if (BI) { if((bMsk>>((((u32)pDst)>>1)&7))&1) goto endpoly; }
+			if (BI) { if((bMsk>>((((uintptr_t)pDst)>>1)&7))&1) goto endpoly; }
 			//  masking
 			if(M) { uDst = *pDst;  if (uDst&0x8000) goto endpoly;  }
 

--- a/src/mdec.cpp
+++ b/src/mdec.cpp
@@ -670,7 +670,7 @@ void mdec1Interrupt() {
 //senquack - Kept original PCSX4ALL mdecFreeze() for reference until
 // savestates can be verified to be working with new code updates here:
 #if 0
-int mdecFreeze(gzFile f, int Mode) {
+int mdecFreeze(void* f, int Mode) {
 	gzfreeze(&mdec, sizeof(mdec));
 	gzfreeze(iq_y, sizeof(iq_y));
 	gzfreeze(iq_uv, sizeof(iq_uv));
@@ -681,7 +681,7 @@ int mdecFreeze(gzFile f, int Mode) {
 
 //senquack - Newer version of above from PCSX Reloaded/Rearmed (still taking
 // unused gzFile first parameter where as Reloaded/Rearmed use void *)
-int mdecFreeze(gzFile f, int Mode) {
+int mdecFreeze(void* f, int Mode) {
 	u8 *base = (u8 *)&psxM[0x100000];
 	u32 v;
 

--- a/src/mdec.h
+++ b/src/mdec.h
@@ -35,6 +35,6 @@ extern void psxDma0(u32 madr, u32 bcr, u32 chcr);
 extern void psxDma1(u32 madr, u32 bcr, u32 chcr);
 extern void mdec0Interrupt();
 extern void mdec1Interrupt(void);
-extern int  mdecFreeze(gzFile f, int Mode);
+extern int  mdecFreeze(void* f, int Mode);
 
 #endif

--- a/src/mdec.h
+++ b/src/mdec.h
@@ -35,6 +35,6 @@ extern void psxDma0(u32 madr, u32 bcr, u32 chcr);
 extern void psxDma1(u32 madr, u32 bcr, u32 chcr);
 extern void mdec0Interrupt();
 extern void mdec1Interrupt(void);
-extern int  mdecFreeze(void* f, int Mode);
+extern int  mdecFreeze(void* f, FreezeMode mode);
 
 #endif

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -640,7 +640,7 @@ int SaveState(const char *file) {
 
 	// senquack - This is used for a small embedded screenshot in PCSX Rearmed,
 	//  but here and in original PCSX4ALL code is just an unused placeholder.
-	if ((pMem = (unsigned char *)malloc(128*96*3)) == NULL ||
+	if ((pMem = (unsigned char *)calloc(128*96*3, 1)) == NULL ||
 	     SaveFuncs.write(f, pMem, 128*96*3) != (128*96*3))
 		goto error;
 	free(pMem);

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -580,7 +580,13 @@ int Load(const char *ExePath) {
 // STATES
 static void *zlib_open(const char *name, const char *mode)
 {
-	return (void*)gzopen(name, mode);
+	// Default zlib compression level is 6, which is a bit slow.. 4 is faster:
+	const char* compr_level = "4";
+	char full_mode[12];
+	strncpy(full_mode, mode, 10);
+	full_mode[10] = '\0';
+	strcat(full_mode, compr_level);
+	return (void*)gzopen(name, full_mode);
 }
 
 static int zlib_read(void *file, void *buf, u32 len)

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -517,7 +517,7 @@ int Load(const char *ExePath) {
 						case 0: /* End of file */
 							break;
 						default:
-							printf("Unknown CPE opcode %02x at position %08x.\n", opcode, ftell(tmpFile) - 1);
+							printf("Unknown CPE opcode %02x at position %08lx.\n", opcode, ftell(tmpFile) - 1);
 							retval = -1;
 							break;
 					}

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -31,7 +31,11 @@ int LoadPlugins(void) {
 
 	ReleasePlugins();
 
-	LoadMcds(Config.Mcd1, Config.Mcd2);
+	if ( LoadMcd(1, Config.Mcd1) < 0 ||
+	     LoadMcd(2, Config.Mcd2) < 0 ) {
+		printf("Error initializing memcards\n");
+		return -1;
+	}
 
 	ret = CDR_init();
 	if (ret < 0) { printf ("Error initializing CD-ROM plugin: %d\n", ret); return -1; }

--- a/src/port/caanoo/port.cpp
+++ b/src/port/caanoo/port.cpp
@@ -432,11 +432,6 @@ void port_printf(int x,int y,char *text)
 	
 }
 
-void port_sync(void)
-{
-	sync();
-}
-
 void port_mute(void)
 {
 	wiz_sound_thread_mute();

--- a/src/port/caanoo/port.h
+++ b/src/port/caanoo/port.h
@@ -29,7 +29,6 @@ extern void video_set(unsigned short* pVideo,unsigned int width,unsigned int hei
 extern void video_clear(void);
 extern void pcsx4all_exit(void);
 extern void port_printf(int x,int y,char *text);
-extern void port_sync(void);
 extern void port_mute(void);
 
 extern unsigned short *SCREEN;

--- a/src/port/sdl/frontend.cpp
+++ b/src/port/sdl/frontend.cpp
@@ -165,7 +165,7 @@ do { \
 	num_items = 0; \
 } while (0)
 
-static char *wildcards[] = {
+static const char *wildcards[] = {
 	//senquack - we do not (yet) support these 3 PocketISO compressed formats
 	// TODO: adapt PCSX Rearmed's cdrcimg.c plugin to get these
 	//"z", "bz", "znx",

--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -1175,11 +1175,6 @@ void port_printf(int x, int y, const char *text)
 	}
 }
 
-void port_sync(void)
-{
-	//sync();
-}
-
 void port_mute(void)
 {
 	//wiz_sound_thread_mute();

--- a/src/port/sdl/port.h
+++ b/src/port/sdl/port.h
@@ -35,7 +35,6 @@ extern void video_set(unsigned short* pVideo,unsigned int width,unsigned int hei
 extern void video_clear(void);
 extern void pcsx4all_exit(void);
 extern void port_printf(int x, int y, const char *text);
-extern void port_sync(void);
 extern void port_mute(void);
 
 extern unsigned short *SCREEN;

--- a/src/port/wiz/port.cpp
+++ b/src/port/wiz/port.cpp
@@ -432,11 +432,6 @@ void port_printf(int x,int y,char *text)
 	
 }
 
-void port_sync(void)
-{
-	sync();
-}
-
 void port_mute(void)
 {
 	wiz_sound_thread_mute();

--- a/src/port/wiz/port.h
+++ b/src/port/wiz/port.h
@@ -36,7 +36,6 @@ extern void video_set(unsigned short* pVideo,unsigned int width,unsigned int hei
 extern void video_clear(void);
 extern void pcsx4all_exit(void);
 extern void port_printf(int x,int y,char *text);
-extern void port_sync(void);
 extern void port_mute(void);
 
 extern unsigned short *SCREEN;

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -41,7 +41,7 @@
 #define pcsx4all_prof_end(A)
 #define pcsx4all_prof_pause(A)
 #define pcsx4all_prof_resume(A)
-#define pcsx4all_prof_add(MSG) 0
+#define pcsx4all_prof_add(MSG)
 #define pcsx4all_prof_show()
 #define pcsx4all_prof_start(A)
 #define pcsx4all_prof_end(A)

--- a/src/psxbios.cpp
+++ b/src/psxbios.cpp
@@ -26,6 +26,7 @@
 #include "psxhw.h"
 #include "gpu.h"
 #include "profiler.h"
+#include <zlib.h>
 
 //We try to emulate bios :) HELP US :P
 

--- a/src/psxbios.cpp
+++ b/src/psxbios.cpp
@@ -917,7 +917,7 @@ void psxBios_malloc(void) { // 33
 		// this fixes Burning Road
 		if (*chunk == 0) {
 			newchunk = chunk;
-			dsize = ((u32)heap_end - (u32)chunk) - 4;
+			dsize = ((uptr)heap_end - (uptr)chunk) - 4;
 			colflag = 1;
 			break;
 		}

--- a/src/psxcommon.h
+++ b/src/psxcommon.h
@@ -115,7 +115,7 @@ struct PcsxSaveFuncs {
 	int   (*read)(void *file, void *buf, u32 len);
 	int   (*write)(void *file, const void *buf, u32 len);
 	long  (*seek)(void *file, long offs, int whence);
-	void  (*close)(void *file);
+	int   (*close)(void *file);
 
 	int   fd;         // The fd we receive from OS's open()
 	int   lib_fd;     // The dupe'd fd we tell compression lib to use

--- a/src/psxcommon.h
+++ b/src/psxcommon.h
@@ -104,19 +104,33 @@ typedef struct {
 
 extern PcsxConfig Config;
 
+/////////////////////////////
+// Savestate file handling //
+/////////////////////////////
+#ifdef _cplusplus
+extern "C" {
+#endif
 struct PcsxSaveFuncs {
-	void *(*open)(const char *name, const char *mode);
+	void *(*open)(const char *name, boolean writing);
 	int   (*read)(void *file, void *buf, u32 len);
 	int   (*write)(void *file, const void *buf, u32 len);
 	long  (*seek)(void *file, long offs, int whence);
 	void  (*close)(void *file);
+
+	int   fd;         // The fd we receive from OS's open()
+	int   lib_fd;     // The dupe'd fd we tell compression lib to use
 };
+#ifdef _cplusplus
+}
+#endif
+
 extern struct PcsxSaveFuncs SaveFuncs;
 
 #define gzfreeze(ptr, size) { \
 	if (Mode == 1) SaveFuncs.write(f, ptr, size); \
 	if (Mode == 0) SaveFuncs.read(f, ptr, size); \
 }
+
 
 //#define BIAS	2
 extern u32 BIAS;

--- a/src/psxcommon.h
+++ b/src/psxcommon.h
@@ -37,7 +37,6 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <assert.h>
-#include <zlib.h>
 
 /* Port includes */
 #include "port.h"
@@ -105,10 +104,18 @@ typedef struct {
 
 extern PcsxConfig Config;
 
+struct PcsxSaveFuncs {
+	void *(*open)(const char *name, const char *mode);
+	int   (*read)(void *file, void *buf, u32 len);
+	int   (*write)(void *file, const void *buf, u32 len);
+	long  (*seek)(void *file, long offs, int whence);
+	void  (*close)(void *file);
+};
+extern struct PcsxSaveFuncs SaveFuncs;
 
 #define gzfreeze(ptr, size) { \
-	if (Mode == 1) gzwrite(f, ptr, size); \
-	if (Mode == 0) gzread(f, ptr, size); \
+	if (Mode == 1) SaveFuncs.write(f, ptr, size); \
+	if (Mode == 0) SaveFuncs.read(f, ptr, size); \
 }
 
 //#define BIAS	2

--- a/src/psxcommon.h
+++ b/src/psxcommon.h
@@ -107,9 +107,6 @@ extern PcsxConfig Config;
 /////////////////////////////
 // Savestate file handling //
 /////////////////////////////
-#ifdef _cplusplus
-extern "C" {
-#endif
 struct PcsxSaveFuncs {
 	void *(*open)(const char *name, boolean writing);
 	int   (*read)(void *file, void *buf, u32 len);
@@ -120,16 +117,22 @@ struct PcsxSaveFuncs {
 	int   fd;         // The fd we receive from OS's open()
 	int   lib_fd;     // The dupe'd fd we tell compression lib to use
 };
+
+// Defined in misc.cpp:
+#ifdef _cplusplus
+extern "C" {
+#endif
+enum FreezeMode {
+	FREEZE_LOAD = 0,
+	FREEZE_SAVE = 1,
+	FREEZE_INFO = 2    // Query plugin for amount of ram to allocate for freeze
+};
+int freeze_rw(void *file, enum FreezeMode mode, void *buf, unsigned len);
 #ifdef _cplusplus
 }
 #endif
 
 extern struct PcsxSaveFuncs SaveFuncs;
-
-#define gzfreeze(ptr, size) { \
-	if (Mode == 1) SaveFuncs.write(f, ptr, size); \
-	if (Mode == 0) SaveFuncs.read(f, ptr, size); \
-}
 
 
 //#define BIAS	2

--- a/src/psxcounters.cpp
+++ b/src/psxcounters.cpp
@@ -624,19 +624,20 @@ void psxRcntInit(void)
 
 /******************************************************************************/
 
-s32 psxRcntFreeze(void *f, s32 Mode)
+int psxRcntFreeze(void *f, FreezeMode mode)
 {
     u32 spuSyncCount = 0;
     u32 count;
     s32 i;
 
-    gzfreeze( &rcnts, sizeof(rcnts) );
-    gzfreeze( &hSyncCount, sizeof(hSyncCount) );
-    gzfreeze( &spuSyncCount, sizeof(spuSyncCount) );
-    gzfreeze( &psxNextCounter, sizeof(psxNextCounter) );
-    gzfreeze( &psxNextsCounter, sizeof(psxNextsCounter) );
+    if (    freeze_rw(f, mode, &rcnts, sizeof(rcnts))
+         || freeze_rw(f, mode, &hSyncCount, sizeof(hSyncCount))
+         || freeze_rw(f, mode, &spuSyncCount, sizeof(spuSyncCount))
+         || freeze_rw(f, mode, &psxNextCounter, sizeof(psxNextCounter))
+         || freeze_rw(f, mode, &psxNextsCounter, sizeof(psxNextsCounter)) )
+    return -1;
 
-    if (Mode == 0)
+    if (mode == FREEZE_LOAD)
     {
         // don't trust things from a savestate
         for( i = 0; i < CounterQuantity; ++i )

--- a/src/psxcounters.cpp
+++ b/src/psxcounters.cpp
@@ -624,7 +624,7 @@ void psxRcntInit(void)
 
 /******************************************************************************/
 
-s32 psxRcntFreeze( gzFile f, s32 Mode )
+s32 psxRcntFreeze(void *f, s32 Mode)
 {
     u32 spuSyncCount = 0;
     u32 count;

--- a/src/psxcounters.h
+++ b/src/psxcounters.h
@@ -48,7 +48,7 @@ extern u32 psxRcntRcount(u32 index);
 extern u32 psxRcntRmode(u32 index);
 extern u32 psxRcntRtarget(u32 index);
 
-extern s32 psxRcntFreeze(void* f, s32 Mode);
+extern int psxRcntFreeze(void* f, FreezeMode mode);
 
 extern unsigned psxGetSpuSync(void);
 

--- a/src/psxcounters.h
+++ b/src/psxcounters.h
@@ -48,7 +48,7 @@ extern u32 psxRcntRcount(u32 index);
 extern u32 psxRcntRmode(u32 index);
 extern u32 psxRcntRtarget(u32 index);
 
-extern s32 psxRcntFreeze(gzFile f, s32 Mode);
+extern s32 psxRcntFreeze(void* f, s32 Mode);
 
 extern unsigned psxGetSpuSync(void);
 

--- a/src/psxhle.cpp
+++ b/src/psxhle.cpp
@@ -146,7 +146,7 @@ static void hleBootstrap(void) { // 0xbfc00000
 	printf("hleBootstrap\n");
 	CheckCdrom();
 	LoadCdrom();
-	printf("CdromLabel: \"%s\": PC = %8.8lx (SP = %8.8lx)\n", CdromLabel, psxRegs.pc, psxRegs.GPR.n.sp);
+	printf("CdromLabel: \"%s\": PC = %8.8x (SP = %8.8x)\n", CdromLabel, psxRegs.pc, psxRegs.GPR.n.sp);
 	pcsx4all_prof_end_with_resume(PCSX4ALL_PROF_HLE,PCSX4ALL_PROF_CPU);
 }
 

--- a/src/psxhw.cpp
+++ b/src/psxhw.cpp
@@ -1241,6 +1241,6 @@ void psxHwWrite32(u32 add, u32 value) {
 	pcsx4all_prof_end_with_resume(PCSX4ALL_PROF_HW_WRITE, PCSX4ALL_PROF_CPU);
 }
 
-int psxHwFreeze(gzFile f, int Mode) {
+int psxHwFreeze(void* f, int Mode) {
 	return 0;
 }

--- a/src/psxhw.cpp
+++ b/src/psxhw.cpp
@@ -1241,6 +1241,6 @@ void psxHwWrite32(u32 add, u32 value) {
 	pcsx4all_prof_end_with_resume(PCSX4ALL_PROF_HW_WRITE, PCSX4ALL_PROF_CPU);
 }
 
-int psxHwFreeze(void* f, int Mode) {
+int psxHwFreeze(void* f, FreezeMode mode) {
 	return 0;
 }

--- a/src/psxhw.h
+++ b/src/psxhw.h
@@ -70,6 +70,6 @@ extern u32  psxHwRead32(u32 add);
 extern void psxHwWrite8 (u32 add, u8  value);
 extern void psxHwWrite16(u32 add, u16 value);
 extern void psxHwWrite32(u32 add, u32 value);
-extern int psxHwFreeze(gzFile f, int Mode);
+extern int psxHwFreeze(void* f, int Mode);
 
 #endif /* __PSXHW_H__ */

--- a/src/psxhw.h
+++ b/src/psxhw.h
@@ -70,6 +70,6 @@ extern u32  psxHwRead32(u32 add);
 extern void psxHwWrite8 (u32 add, u8  value);
 extern void psxHwWrite16(u32 add, u16 value);
 extern void psxHwWrite32(u32 add, u32 value);
-extern int psxHwFreeze(void* f, int Mode);
+extern int psxHwFreeze(void* f, FreezeMode mode);
 
 #endif /* __PSXHW_H__ */

--- a/src/sio.cpp
+++ b/src/sio.cpp
@@ -25,6 +25,7 @@
 #include "sio.h"
 #include "psxevents.h"
 #include <sys/stat.h>
+#include <unistd.h>
 
 // Status Flags
 #define TX_RDY		0x0001
@@ -486,8 +487,9 @@ void SaveMcd(char *mcd, char *data, uint32_t adr, int size) {
 			fseek(f, adr, SEEK_SET);
 
 		fwrite(data + adr, 1, size, f);
+		fflush(f);
+		fsync(fileno(f));
 		fclose(f);
-		port_sync();
 		return;
 	}
 
@@ -647,8 +649,9 @@ void CreateMcd(char *mcd) {
 	while ((s--) >= 0)
 		fputc(0, f);
 
+	fflush(f);
+	fsync(fileno(f));
 	fclose(f);
-	port_sync();
 }
 
 void ConvertMcd(char *mcd, char *data) {
@@ -660,8 +663,9 @@ void ConvertMcd(char *mcd, char *data) {
 		f = fopen(mcd, "wb");
 		if (f != NULL) {		
 			fwrite(data-3904, 1, MCD_SIZE+3904, f);
+			fflush(f);
+			fsync(fileno(f));
 			fclose(f);
-			port_sync();
 		}		
 		f = fopen(mcd, "r+");		
 		s = s + 3904;
@@ -690,8 +694,9 @@ void ConvertMcd(char *mcd, char *data) {
 		fputc(0, f); s--;
 		fputc(0xff, f);
 		while (s-- > (MCD_SIZE+1)) fputc(0, f);
+		fflush(f);
+		fsync(fileno(f));
 		fclose(f);
-		port_sync();
 	} else if(strstr(mcd, ".mem") || strstr(mcd,".vgs")) {		
 		f = fopen(mcd, "wb");
 		if (f != NULL) {		
@@ -713,14 +718,16 @@ void ConvertMcd(char *mcd, char *data) {
 		fputc(0, f); s--;
 		fputc(2, f);
 		while (s-- > (MCD_SIZE+1)) fputc(0, f);
+		fflush(f);
+		fsync(fileno(f));
 		fclose(f);
-		port_sync();
 	} else {
 		f = fopen(mcd, "wb");
 		if (f != NULL) {		
 			fwrite(data, 1, MCD_SIZE, f);
+			fflush(f);
+			fsync(fileno(f));
 			fclose(f);
-			port_sync();
 		}
 	}
 }

--- a/src/sio.cpp
+++ b/src/sio.cpp
@@ -847,19 +847,21 @@ void GetMcdBlockInfo(int mcd, int block, McdBlock *Info) {
 	strncpy(Info->Name, ptr, 16);
 }
 
-int sioFreeze(void* f, int Mode) {
-	gzfreeze(buf, sizeof(buf));
-	gzfreeze(&StatReg, sizeof(StatReg));
-	gzfreeze(&ModeReg, sizeof(ModeReg));
-	gzfreeze(&CtrlReg, sizeof(CtrlReg));
-	gzfreeze(&BaudReg, sizeof(BaudReg));
-	gzfreeze(&bufcount, sizeof(bufcount));
-	gzfreeze(&parp, sizeof(parp));
-	gzfreeze(&mcdst, sizeof(mcdst));
-	gzfreeze(&rdwr, sizeof(rdwr));
-	gzfreeze(&adrH, sizeof(adrH));
-	gzfreeze(&adrL, sizeof(adrL));
-	gzfreeze(&padst, sizeof(padst));
-
-	return 0;
+int sioFreeze(void* f, FreezeMode mode)
+{
+	if (    freeze_rw(f, mode, buf, sizeof(buf))
+	     || freeze_rw(f, mode, &StatReg, sizeof(StatReg))
+	     || freeze_rw(f, mode, &ModeReg, sizeof(ModeReg))
+	     || freeze_rw(f, mode, &CtrlReg, sizeof(CtrlReg))
+	     || freeze_rw(f, mode, &BaudReg, sizeof(BaudReg))
+	     || freeze_rw(f, mode, &bufcount, sizeof(bufcount))
+	     || freeze_rw(f, mode, &parp, sizeof(parp))
+	     || freeze_rw(f, mode, &mcdst, sizeof(mcdst))
+	     || freeze_rw(f, mode, &rdwr, sizeof(rdwr))
+	     || freeze_rw(f, mode, &adrH, sizeof(adrH))
+	     || freeze_rw(f, mode, &adrL, sizeof(adrL))
+	     || freeze_rw(f, mode, &padst, sizeof(padst)) )
+		return -1;
+	else
+		return 0;
 }

--- a/src/sio.cpp
+++ b/src/sio.cpp
@@ -400,6 +400,7 @@ void sioInterrupt() {
 }
 
 void LoadMcd(int mcd, char *str) {
+	size_t bytes_read;
 	FILE *f;
 	char *data = NULL;
 
@@ -434,11 +435,15 @@ void LoadMcd(int mcd, char *str) {
 				else if(_buf.st_size == MCD_SIZE + 3904)
 					fseek(f, 3904, SEEK_SET);
 			}			
-			fread(data, 1, MCD_SIZE, f);
+			if ((bytes_read = fread(data, 1, MCD_SIZE, f)) != MCD_SIZE) {
+				printf("Failed reading data from new memory card %s!\n", str);
+				printf("Wanted %zu bytes and got %zu\n", (size_t)MCD_SIZE, bytes_read);
+			}
+
 			fclose(f);
 		}
 		else
-			printf("Memory card %s failed to load!\n", str);
+			printf("Memory card %s failed to open!\n", str);
 	}
 	else {
 		struct stat _buf;
@@ -449,7 +454,11 @@ void LoadMcd(int mcd, char *str) {
 			else if(_buf.st_size == MCD_SIZE + 3904)
 				fseek(f, 3904, SEEK_SET);
 		}
-		fread(data, 1, MCD_SIZE, f);
+		if ((bytes_read = fread(data, 1, MCD_SIZE, f)) != MCD_SIZE) {
+			printf("Failed reading data from memory card %s!\n", str);
+			printf("Wanted %zu bytes and got %zu\n", (size_t)MCD_SIZE, bytes_read);
+		}
+
 		fclose(f);
 	}
 }

--- a/src/sio.cpp
+++ b/src/sio.cpp
@@ -840,7 +840,7 @@ void GetMcdBlockInfo(int mcd, int block, McdBlock *Info) {
 	strncpy(Info->Name, ptr, 16);
 }
 
-int sioFreeze(gzFile f, int Mode) {
+int sioFreeze(void* f, int Mode) {
 	gzfreeze(buf, sizeof(buf));
 	gzfreeze(&StatReg, sizeof(StatReg));
 	gzfreeze(&ModeReg, sizeof(ModeReg));

--- a/src/sio.h
+++ b/src/sio.h
@@ -51,11 +51,9 @@ void netError();
 extern void sioInterrupt(void);
 extern int sioFreeze(void* f, FreezeMode mode);
 
-extern void LoadMcd(int mcd, char *str);
-extern void LoadMcds(char *mcd1, char *mcd2);
-extern void SaveMcd(char *mcd, char *data, uint32_t adr, int size);
-extern void CreateMcd(char *mcd);
-extern void ConvertMcd(char *mcd, char *data);
+extern int LoadMcd(int mcd_num, char *mcd);
+extern int SaveMcd(char *mcd, char *data, uint32_t adr, int size);
+extern int CreateMcd(char *mcd);
 
 typedef struct {
 	char Title[48 + 1]; // Title in ASCII

--- a/src/sio.h
+++ b/src/sio.h
@@ -49,7 +49,7 @@ extern unsigned short sioReadBaud16(void);
 void netError();
 
 extern void sioInterrupt(void);
-extern int sioFreeze(gzFile f, int Mode);
+extern int sioFreeze(void* f, int Mode);
 
 extern void LoadMcd(int mcd, char *str);
 extern void LoadMcds(char *mcd1, char *mcd2);

--- a/src/sio.h
+++ b/src/sio.h
@@ -49,7 +49,7 @@ extern unsigned short sioReadBaud16(void);
 void netError();
 
 extern void sioInterrupt(void);
-extern int sioFreeze(void* f, int Mode);
+extern int sioFreeze(void* f, FreezeMode mode);
 
 extern void LoadMcd(int mcd, char *str);
 extern void LoadMcds(char *mcd1, char *mcd2);


### PR DESCRIPTION
Added zlib savestate compression support: Savestates are now ~1.6MB versus ~4.3MB before. As a result, they are also faster to save since level-4 zlib compression is pretty quick versus writing uncompressed data to SD.

Savestates are synced to disk before returning to emulator. **TODO** : Add frontend "wait" screen when saving a new state, also improve savestate loading/saving method.. the method used by PCSX4ALL is a horrible hack in psxcounters.cpp

Error checking has been added to most file operations, including savestates, memcards, and CDROM ops.

Most compiler warnings have now been addressed.