### PR TITLE
Windows fixes

### DIFF
--- a/src/port/sdl/port.h
+++ b/src/port/sdl/port.h
@@ -12,6 +12,15 @@
 #include <sys/types.h>
 #include <assert.h>
 
+///////////////////////////
+// Windows compatibility //
+///////////////////////////
+#if defined(_WIN32) && !defined(__CYGWIN__)
+// Windows lacks fsync():
+static inline int fsync(int f) { return 0; }
+#endif
+
+
 #define UDIV(n,d) ((n)/(d))
 #define SDIV(n,d) ((n)/(d))
 

--- a/src/psxcommon.h
+++ b/src/psxcommon.h
@@ -114,8 +114,10 @@ struct PcsxSaveFuncs {
 	long  (*seek)(void *file, long offs, int whence);
 	int   (*close)(void *file);
 
+#if !(defined(_WIN32) && !defined(__CYGWIN__))
 	int   fd;         // The fd we receive from OS's open()
 	int   lib_fd;     // The dupe'd fd we tell compression lib to use
+#endif
 };
 
 // Defined in misc.cpp:


### PR DESCRIPTION
Provide fsync() stub func for non-Cygwin Windows builds, since Windows lacks it natively.

Let zlib handle all savestate file operations on non-Cygwin Windows builds.