### PR TITLE
Memcard work

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -23,7 +23,7 @@
 */
 
 //senquack NOTE: CDROM functions have been updated to PCSX Reloaded code
-// TODO: update remaining functions like BIOS/savestates?
+// TODO: update remaining functions like BIOS
 
 #include "misc.h"
 #include "cdrom.h"
@@ -34,6 +34,7 @@
 #include "port.h"
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <zlib.h>
 #if !defined(O_BINARY)
 #define O_BINARY 0
@@ -932,4 +933,17 @@ int CheckState(const char *file) {
 		return -1;
 
 	return 0;
+}
+
+////////////////////////////
+// Misc utility functions //
+////////////////////////////
+
+bool FileExists(const char* filename)
+{
+	if (!filename || *filename == '\0')
+		return false;
+	struct stat st;
+	int result = stat(filename, &st);
+	return result == 0;
 }

--- a/src/misc.h
+++ b/src/misc.h
@@ -77,4 +77,5 @@ extern int toLoadState;
 extern int toExit;
 extern char *SaveState_filename;
 
+extern bool FileExists(const char* filename);
 #endif /* __MISC_H__ */

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -31,11 +31,8 @@ int LoadPlugins(void) {
 
 	ReleasePlugins();
 
-	if ( LoadMcd(MCD1, Config.Mcd1) < 0 ||
-	     LoadMcd(MCD2, Config.Mcd2) < 0 ) {
-		printf("Error initializing memcards\n");
-		return -1;
-	}
+	LoadMcd(MCD1, Config.Mcd1); //Memcard 1
+	LoadMcd(MCD2, Config.Mcd2); //Memcard 2
 
 	ret = CDR_init();
 	if (ret < 0) { printf ("Error initializing CD-ROM plugin: %d\n", ret); return -1; }

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -31,8 +31,8 @@ int LoadPlugins(void) {
 
 	ReleasePlugins();
 
-	if ( LoadMcd(1, Config.Mcd1) < 0 ||
-	     LoadMcd(2, Config.Mcd2) < 0 ) {
+	if ( LoadMcd(MCD1, Config.Mcd1) < 0 ||
+	     LoadMcd(MCD2, Config.Mcd2) < 0 ) {
 		printf("Error initializing memcards\n");
 		return -1;
 	}

--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -454,6 +454,11 @@ void pad_update(void)
 
 	// SELECT+START for menu
 	if (keys[SDLK_ESCAPE] && keys[SDLK_RETURN] && !keys[SDLK_LALT]) {
+		//Sync and close any memcard files opened for writing
+		//TODO: Disallow entering menu until they are synced/closed
+		// automatically, displaying message that write is in progress.
+		sioSyncMcds();
+
 		emu_running = false;
 		GameMenu();
 		emu_running = true;

--- a/src/psxbios.cpp
+++ b/src/psxbios.cpp
@@ -1145,20 +1145,13 @@ _start:
 }
 
 void psxBios_format() { // 0x41
-	if (strcmp(Ra0, "bu00:") == 0 && Config.Mcd1[0] != '\0')
-	{
-		CreateMcd(Config.Mcd1);
-		LoadMcd(MCD1, Config.Mcd1);
+	if (strcmp(Ra0, "bu00:") == 0) {
+		sioMcdFormat(MCD1);
 		v0 = 1;
-	}
-	else if (strcmp(Ra0, "bu10:") == 0 && Config.Mcd2[0] != '\0')
-	{
-		CreateMcd(Config.Mcd2);
-		LoadMcd(MCD2, Config.Mcd2);
+	} else if (strcmp(Ra0, "bu10:") == 0) {
+		sioMcdFormat(MCD2);
 		v0 = 1;
-	}
-	else
-	{
+	} else {
 		v0 = 0;
 	}
 	pc0 = ra;

--- a/src/psxbios.cpp
+++ b/src/psxbios.cpp
@@ -1148,13 +1148,13 @@ void psxBios_format() { // 0x41
 	if (strcmp(Ra0, "bu00:") == 0 && Config.Mcd1[0] != '\0')
 	{
 		CreateMcd(Config.Mcd1);
-		LoadMcd(1, Config.Mcd1);
+		LoadMcd(MCD1, Config.Mcd1);
 		v0 = 1;
 	}
 	else if (strcmp(Ra0, "bu10:") == 0 && Config.Mcd2[0] != '\0')
 	{
 		CreateMcd(Config.Mcd2);
-		LoadMcd(2, Config.Mcd2);
+		LoadMcd(MCD2, Config.Mcd2);
 		v0 = 1;
 	}
 	else
@@ -1911,7 +1911,7 @@ void psxBios_UnDeliverEvent(void) { // 0x20
 			FDesc[1 + mcd].mcfile = i; \
 			/*printf("openC %s\n", ptr);*/ \
 			v0 = 1 + mcd; \
-			SaveMcd((mcd==1?Config.Mcd1:Config.Mcd2), Mcd##mcd##Data, 128 * i, 128); \
+			SaveMcd((mcd==1 ? MCD1 : MCD2), Mcd##mcd##Data, 128 * i, 128); \
 			break; \
 		} \
 	} \
@@ -2012,7 +2012,7 @@ void psxBios_read(void) { // 0x34
 	ptr = Mcd##mcd##Data + offset; \
 	memcpy(ptr, Ra1, a2); \
 	FDesc[1 + mcd].offset += a2; \
-	SaveMcd((mcd==1?Config.Mcd1:Config.Mcd2), Mcd##mcd##Data, offset, a2); \
+	SaveMcd((mcd==1 ? MCD1 : MCD2), Mcd##mcd##Data, offset, a2); \
 	if (FDesc[1 + mcd].mode & 0x8000) v0 = 0; \
 	else v0 = a2; \
 	DeliverEvent(0x11, 0x2); /* 0xf0000011, 0x0004 */ \
@@ -2187,7 +2187,7 @@ void psxBios_nextfile(void) { // 43
 		memset(ptr+0xa+namelen, 0, 0x75-namelen); \
 		for (j=0; j<127; j++) cxor^= ptr[j]; \
 		ptr[127] = cxor; \
-		SaveMcd((mcd==1?Config.Mcd1:Config.Mcd2), Mcd##mcd##Data, 128 * i + 0xa, 0x76); \
+		SaveMcd((mcd==1 ? MCD1 : MCD2), Mcd##mcd##Data, 128 * i + 0xa, 0x76); \
 		v0 = 1; \
 		break; \
 	} \
@@ -2229,7 +2229,7 @@ void psxBios_rename(void) { // 44
 		if ((*ptr & 0xF0) != 0x50) continue; \
 		if (strcmp(Ra0+5, ptr+0xa)) continue; \
 		*ptr = (*ptr & 0xf) | 0xA0; \
-		SaveMcd((mcd==1?Config.Mcd1:Config.Mcd2), Mcd##mcd##Data, 128 * i, 1); \
+		SaveMcd((mcd==1 ? MCD1 : MCD2), Mcd##mcd##Data, 128 * i, 1); \
 		/*printf("delete %s\n", ptr+0xa);*/ \
 		v0 = 1; \
 		break; \
@@ -2313,10 +2313,10 @@ void psxBios__card_write(void) { // 0x4e
 	if (pa2) {
 		if (port == 0) {
 			memcpy(Mcd1Data + a1 * 128, pa2, 128);
-			SaveMcd(Config.Mcd1, Mcd1Data, a1 * 128, 128);
+			SaveMcd(MCD1, Mcd1Data, a1 * 128, 128);
 		} else {
 			memcpy(Mcd2Data + a1 * 128, pa2, 128);
-			SaveMcd(Config.Mcd2, Mcd2Data, a1 * 128, 128);
+			SaveMcd(MCD2, Mcd2Data, a1 * 128, 128);
 		}
 	}
 

--- a/src/psxevents.cpp
+++ b/src/psxevents.cpp
@@ -220,7 +220,8 @@ EventQueue::EventFunc * const EventQueue::eventFuncs[PSXINT_COUNT] = {
 	[PSXINT_CDRPLAY]         = cdrPlayInterrupt,
 	[PSXINT_SPUIRQ]          = HandleSPU_IRQ,
 	[PSXINT_SPU_UPDATE]      = UpdateSPU,
-	[PSXINT_RESET_CYCLE_VAL] = psxResetCycleValue
+	[PSXINT_RESET_CYCLE_VAL] = psxResetCycleValue,
+	[PSXINT_SIO_SYNC_MCD]    = sioSyncMcds
 };
 
 EventQueue psxEventQueue;

--- a/src/psxevents.h
+++ b/src/psxevents.h
@@ -54,6 +54,7 @@ enum psxEventType {
 	                       // interval for SPU update-and-feed)
 	PSXINT_RESET_CYCLE_VAL,          // Reset psxRegs.cycle value to 0 to ensure
 	                                 //  it can never overflow
+	PSXINT_SIO_SYNC_MCD,             // Flush/sync/close memcards opened for writing
 	PSXINT_COUNT,
 	PSXINT_NEXT_EVENT = PSXINT_COUNT //The most imminent event's entry is
 	                                 // always copied to this slot in

--- a/src/sio.h
+++ b/src/sio.h
@@ -56,16 +56,25 @@ enum MemcardNum {
 	MCD2 = 1
 };
 
+/* High-level memcard operations
+ * (Emulator code should use these when possible/appropriate)
+ */
 void sioSyncMcds(void);
-void sioMcdWrite(enum MemcardNum mcd_num, const char *src, uint32_t adr, int size);
-void sioMcdRead(enum MemcardNum mcd_num, char *dst, uint32_t adr, int size);
+int sioMcdWrite(enum MemcardNum mcd_num, const char *src, uint32_t adr, int size);
+int sioMcdRead(enum MemcardNum mcd_num, char *dst, uint32_t adr, int size);
 char* sioMcdDataPtr(enum MemcardNum mcd_num);
-bool sioMcdEnabled(enum MemcardNum mcd_num);
+bool sioMcdInserted(enum MemcardNum mcd_num);
+int sioMcdFormat(enum MemcardNum mcd_num);
 
+/* Low-level memcard operations, used by above functions
+ *  and any memcard management code.
+ */
 int FlushMcd(enum MemcardNum mcd_num, bool sync_file);
+int EjectMcd(enum MemcardNum mcd_num);
+void InitMcdData(char *mcd_data);
+int CreateMcd(char *filename, bool overwrite_file);
 int LoadMcd(enum MemcardNum mcd_num, char* filename);
 int SaveMcd(enum MemcardNum mcd_num, uint32_t adr, int size);
-int CreateMcd(char *filename);
 
 typedef struct {
 	char Title[48 + 1]; // Title in ASCII

--- a/src/sio.h
+++ b/src/sio.h
@@ -56,12 +56,15 @@ enum MemcardNum {
 	MCD2 = 1
 };
 
-extern char Mcd1Data[MCD_SIZE], Mcd2Data[MCD_SIZE];
-
 void sioSyncMcds(void);
-int FlushMcd(enum MemcardNum mcd_num, boolean sync_file);
+void sioMcdWrite(enum MemcardNum mcd_num, const char *src, uint32_t adr, int size);
+void sioMcdRead(enum MemcardNum mcd_num, char *dst, uint32_t adr, int size);
+char* sioMcdDataPtr(enum MemcardNum mcd_num);
+bool sioMcdEnabled(enum MemcardNum mcd_num);
+
+int FlushMcd(enum MemcardNum mcd_num, bool sync_file);
 int LoadMcd(enum MemcardNum mcd_num, char* filename);
-int SaveMcd(enum MemcardNum mcd_num, char *data, uint32_t adr, int size);
+int SaveMcd(enum MemcardNum mcd_num, uint32_t adr, int size);
 int CreateMcd(char *filename);
 
 typedef struct {

--- a/src/sio.h
+++ b/src/sio.h
@@ -28,10 +28,6 @@
 #include "plugins.h"
 #include "psemu_plugin_defs.h"
 
-#define MCD_SIZE	(1024 * 8 * 16)
-
-extern char Mcd1Data[MCD_SIZE], Mcd2Data[MCD_SIZE];
-
 extern void sioInit(void);
 
 extern void sioWrite8(unsigned char value);
@@ -46,14 +42,27 @@ extern unsigned short sioReadMode16(void);
 extern unsigned short sioReadCtrl16(void);
 extern unsigned short sioReadBaud16(void);
 
-void netError();
-
 extern void sioInterrupt(void);
 extern int sioFreeze(void* f, FreezeMode mode);
 
-extern int LoadMcd(int mcd_num, char *mcd);
-extern int SaveMcd(char *mcd, char *data, uint32_t adr, int size);
-extern int CreateMcd(char *mcd);
+////////////////////////
+// Memcard operations //
+////////////////////////
+
+#define MCD_SIZE	(1024 * 8 * 16)
+
+enum MemcardNum {
+	MCD1 = 0,
+	MCD2 = 1
+};
+
+extern char Mcd1Data[MCD_SIZE], Mcd2Data[MCD_SIZE];
+
+void sioSyncMcds(void);
+int FlushMcd(enum MemcardNum mcd_num, boolean sync_file);
+int LoadMcd(enum MemcardNum mcd_num, char* filename);
+int SaveMcd(enum MemcardNum mcd_num, char *data, uint32_t adr, int size);
+int CreateMcd(char *filename);
 
 typedef struct {
 	char Title[48 + 1]; // Title in ASCII
@@ -65,6 +74,6 @@ typedef struct {
 	unsigned char Flags;
 } McdBlock;
 
-extern void GetMcdBlockInfo(int mcd, int block, McdBlock *info);
+void GetMcdBlockInfo(enum MemcardNum mcd_num, int block, McdBlock *Info);
 
 #endif


### PR DESCRIPTION
Move sio-related globals into struct psxSio. Initialize struct in sioInit().

Improve memcard interface/implementation and error reporting/handling:
- Divide memcard interface between higher-level interface for emulator use and lower-level interface to service it (or for use by frontend in future memcard manager).
- Eliminate large number of unnecessary system calls and file writes/syncs by keeping memcard files open for writing across several incoming writes from emulated games. Before this change, a single 8KB (1 block) game save would result in 64 separate series of open/seek/write/sync/close operations, once for each sector written. Now it is just one series.
- New PSXINT_SIO_SYNC_MCD event ensures a memcard file open for writing is closed a small amount of time after last incoming write (see above).
- Detect redundant memcard writes and prevent them from resulting in an actual file write. This prevents BIOS from causing unnecessary flash wear.

TODO: add memcard manager to frontend.

