### PR TITLE
perfmon: Add performance monitor (FPS & CPU usage)

### DIFF
--- a/Makefile.caanoo
+++ b/Makefile.caanoo
@@ -63,7 +63,13 @@ CFLAGS += -DGPU_UNAI_USE_INT_DIV_MULTINV
 
 LDFLAGS = -lm -lpthread
 
-OBJDIRS = obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) obj/interpreter obj/interpreter/$(INTERPRETER) obj/recompiler obj/recompiler/$(RECOMPILER) obj/zlib obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE)
+OBJDIRS = \
+	obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) \
+	obj/interpreter obj/interpreter/$(INTERPRETER) \
+	obj/recompiler obj/recompiler/$(RECOMPILER) \
+	obj/zlib \
+	obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE) \
+	obj/plugin_lib
 
 all: maketree $(TARGET) pcsx4all_caanoo.gpe
 
@@ -100,6 +106,7 @@ OBJS += obj/port/caanoo/port.o obj/port/caanoo/wiz_lib.o obj/port/caanoo/warm.o 
 	obj/port/caanoo/div.o
 
 OBJS += obj/profiler.o obj/debug.o
+OBJS += obj/plugin_lib/perfmon.o
 
 CXXFLAGS := $(CFLAGS) -fno-rtti
 

--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -67,7 +67,8 @@ LDFLAGS = $(SDL_LIBS) -lSDL_mixer -lSDL_image -lrt -lz
 OBJDIRS = obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) \
 	  obj/interpreter obj/interpreter/$(INTERPRETER) \
 	  obj/recompiler obj/recompiler/$(RECOMPILER) \
-	  obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE)
+	  obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE) \
+	  obj/plugin_lib
 
 all: maketree $(TARGET)
 
@@ -93,6 +94,7 @@ OBJS += obj/port/$(PORT)/port.o
 OBJS += obj/port/$(PORT)/frontend.o
 
 OBJS += obj/profiler.o obj/debug.o
+OBJS += obj/plugin_lib/perfmon.o
 
 #******************************************
 # senquack - spu_pcsxrearmed section BEGIN

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -63,7 +63,8 @@ LDFLAGS = $(SDL_LIBS) -lSDL_mixer -lSDL_image -lpthread -lz
 OBJDIRS = \
 	obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) \
 	obj/interpreter obj/interpreter/$(INTERPRETER) \
-	obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE)
+	obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE) \
+	obj/plugin_lib
 
 all: maketree $(TARGET)
 
@@ -83,6 +84,7 @@ OBJS += obj/port/$(PORT)/port.o
 OBJS += obj/port/$(PORT)/frontend.o
 
 OBJS += obj/profiler.o obj/debug.o
+OBJS += obj/plugin_lib/perfmon.o
 
 #******************************************
 # senquack - spu_pcsxrearmed section BEGIN

--- a/Makefile.win32
+++ b/Makefile.win32
@@ -61,7 +61,8 @@ LDFLAGS = $(SDL_LIBS) -lSDL_mixer -lSDL_image -lz
 OBJDIRS = \
 	obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) \
 	obj/interpreter obj/interpreter/$(INTERPRETER) \
-	obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE)
+	obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE) \
+	obj/plugin_lib
 
 all: maketree $(TARGET)
 
@@ -77,11 +78,11 @@ OBJS += obj/gte/$(GTE)/gte.o
 OBJS += obj/gpu/$(GPU)/gpu.o
 OBJS += obj/spu/$(SPU)/spu.o
 
-
 OBJS += obj/port/$(PORT)/port.o
 OBJS += obj/port/$(PORT)/frontend.o
 
 OBJS += obj/profiler.o obj/debug.o
+OBJS += obj/plugin_lib/perfmon.o
 
 #******************************************
 # senquack - spu_pcsxrearmed section BEGIN

--- a/Makefile.wiz
+++ b/Makefile.wiz
@@ -68,7 +68,13 @@ CFLAGS += -DGPU_UNAI_USE_INT_DIV_MULTINV
 
 LDFLAGS = -lm -lpthread
 
-OBJDIRS = obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) obj/interpreter obj/interpreter/$(INTERPRETER) obj/recompiler obj/recompiler/$(RECOMPILER) obj/zlib obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE)
+OBJDIRS = \
+	obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) \
+	obj/interpreter obj/interpreter/$(INTERPRETER) \
+	obj/recompiler obj/recompiler/$(RECOMPILER) \
+	obj/zlib \
+	obj/port obj/port/$(PORT) obj/gte obj/gte/$(GTE) \
+	obj/plugin_lib
 
 all: maketree $(TARGET) pcsx4all_wiz.gpe
 
@@ -105,6 +111,7 @@ OBJS += obj/port/wiz/port.o obj/port/wiz/wiz_lib.o obj/port/wiz/uppermem.o obj/p
 	obj/port/wiz/div.o
 
 OBJS += obj/profiler.o obj/debug.o
+OBJS += obj/plugin_lib/perfmon.o
 
 CXXFLAGS := $(CFLAGS) -fno-rtti
 

--- a/src/plugin_lib/perfmon.cpp
+++ b/src/plugin_lib/perfmon.cpp
@@ -1,0 +1,228 @@
+/***************************************************************************
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02111-1307 USA.           *
+ ***************************************************************************/
+
+/*
+ * FPS & CPU-usage monitoring
+ *
+ * Added November 2016 by senquack (Daniel Silsby)
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/time.h>
+
+// We only support CPU stats on UNIX platforms
+#ifndef _WIN32
+#include <sys/resource.h>
+#define PERFMON_CPU_STATS
+#endif
+
+#ifdef _WIN32
+#ifndef suseconds_t
+#define suseconds_t long
+#endif
+#endif //_WIN32
+
+#include "perfmon.h"
+#include "psxcommon.h"
+
+static struct {
+	struct timeval tv_last;
+	unsigned frame_ctr;
+
+	struct {
+		int num_entries;
+		float fps[5];
+#ifdef PERFMON_CPU_STATS
+		float cpu[5];
+#endif
+	} buf;
+
+	float fps_cur, fps_avg, fps_min, fps_max;
+#ifdef PERFMON_CPU_STATS
+	float cpu_cur, cpu_avg, cpu_min, cpu_max;
+	struct timeval tv_last_ru_utime, tv_last_ru_stime;
+#endif
+} pmon;
+
+// Returns # of microseconds spanning interval between tv and tv_old
+static inline suseconds_t tvdiff_usec(const timeval &tv, const timeval &tv_old)
+{
+	return (tv.tv_sec - tv_old.tv_sec) * 1000000 + tv.tv_usec - tv_old.tv_usec;
+}
+
+// Returns # of microseconds total in tv1 and tv2
+static inline suseconds_t tvsum_usec(const timeval &tv1, const timeval &tv2)
+{
+	return (tv1.tv_sec + tv2.tv_sec) * 1000000 + tv1.tv_usec + tv2.tv_usec;
+}
+
+#ifdef PERFMON_CPU_STATS
+static void pmonInitCpuUsage()
+{
+	struct rusage ru;
+	if (getrusage(RUSAGE_SELF, &ru) < 0)
+		return;
+
+	pmon.tv_last_ru_utime = ru.ru_utime;
+	pmon.tv_last_ru_stime = ru.ru_stime;
+}
+
+static float pmonGetCpuUsage(suseconds_t usecs_span)
+{
+	struct rusage ru;
+	if (usecs_span == 0 || getrusage(RUSAGE_SELF, &ru) < 0)
+		return 0;
+	suseconds_t usecs_used = tvdiff_usec(ru.ru_utime, pmon.tv_last_ru_utime) +
+	                         tvdiff_usec(ru.ru_stime, pmon.tv_last_ru_stime);
+	pmon.tv_last_ru_utime = ru.ru_utime;
+	pmon.tv_last_ru_stime = ru.ru_stime;
+	return (float)(100 * usecs_used) / (float)usecs_span;
+}
+#endif //PERFMON_CPU_STATS
+
+void pmonReset()
+{
+	pmon.frame_ctr = 0;
+	pmon.fps_cur = 0;
+	pmon.tv_last.tv_sec = pmon.tv_last.tv_usec = 0;
+	memset(&pmon.buf, 0, sizeof(pmon.buf));
+#ifdef PERFMON_CPU_STATS
+	pmon.cpu_cur = 0;
+	pmonInitCpuUsage();
+#endif
+}
+
+bool pmonUpdate()
+{
+	bool ret = false;
+	pmon.frame_ctr++;
+	struct timeval tv_now;
+	gettimeofday(&tv_now, 0);
+	suseconds_t diff = tvdiff_usec(tv_now, pmon.tv_last);
+
+	if (diff >= 1000000) {
+		ret = true;
+		pmon.fps_cur = (float)(1000000 * pmon.frame_ctr) / (float)diff;
+#ifdef PERFMON_CPU_STATS
+		pmon.cpu_cur = pmonGetCpuUsage(diff);
+#endif
+		pmon.tv_last = tv_now;
+		pmon.frame_ctr = 0;
+
+		bool new_detailed_stats = false;
+		if (Config.PerfmonDetailedStats) {
+			// Move old buffer entries to top, insert new entry at bottom
+			pmon.buf.fps[pmon.buf.num_entries] = pmon.fps_cur;
+#ifdef PERFMON_CPU_STATS
+			pmon.buf.cpu[pmon.buf.num_entries] = pmon.cpu_cur;
+#endif
+			pmon.buf.num_entries++;
+
+			if (pmon.buf.num_entries >= 5) {
+				new_detailed_stats = true;
+				pmon.buf.num_entries = 0;
+
+				// Some very large pos/neg values to establish max/mins
+				pmon.fps_min = (float)+1000000;
+				pmon.fps_max = (float)-1000000;
+				int fps_min_idx = 0;
+
+				// Determine min/max value of all FPS entries
+				for (int i=0; i < 5; ++i) {
+					if (pmon.buf.fps[i] > pmon.fps_max) {
+						pmon.fps_max = pmon.buf.fps[i];
+					}
+					if (pmon.buf.fps[i] < pmon.fps_min) {
+						pmon.fps_min = pmon.buf.fps[i];
+						fps_min_idx = i;
+					}
+				}
+
+				// Compute FPS average. We don't include the minimum FPS
+				//  value so external events don't skew the results too much.
+				pmon.fps_avg = 0;
+				for (int i=0; i < 5; ++i) {
+					if (i != fps_min_idx) pmon.fps_avg += pmon.buf.fps[i];
+				}
+				pmon.fps_avg *= 0.25f;
+
+#ifdef PERFMON_CPU_STATS
+				// Some very large pos/neg values to establish max/mins
+				pmon.cpu_min = (float)+1000000;
+				pmon.cpu_max = (float)-1000000;
+				int cpu_max_idx = 0;
+
+				// Determine min/max value of all CPU entries
+				for (int i=0; i < 5; ++i) {
+					if (pmon.buf.cpu[i] > pmon.cpu_max) {
+						pmon.cpu_max = pmon.buf.cpu[i];
+						cpu_max_idx = i;
+					}
+					if (pmon.buf.cpu[i] < pmon.cpu_min) {
+						pmon.cpu_min = pmon.buf.cpu[i];
+					}
+				}
+
+				// Compute average values. We don't include the maximum CPU
+				//  value so external events don't skew the results too much.
+				pmon.cpu_avg = 0;
+				for (int i=0; i < 5; ++i) {
+					if (i != cpu_max_idx) pmon.cpu_avg += pmon.buf.cpu[i];
+				}
+				pmon.cpu_avg *= 0.25f;
+#endif
+			}
+		}
+
+		if (Config.PerfmonConsoleOutput)
+			pmonPrintStats(new_detailed_stats);
+	}
+	return ret;
+}
+
+void pmonPause()
+{
+}
+
+void pmonResume()
+{
+	pmon.frame_ctr = 0;
+	gettimeofday(&pmon.tv_last, 0);
+#ifdef PERFMON_CPU_STATS
+	pmonInitCpuUsage();
+#endif
+}
+
+void pmonPrintStats(bool print_detailed_stats)
+{
+#ifdef PERFMON_CPU_STATS
+	printf("FPS: %6.1f  CPU: %6.1f%%\n", pmon.fps_cur, pmon.cpu_cur);
+	if (print_detailed_stats) {
+		printf("FPS min: %6.1f  max: %6.1f  avg: %6.1f\n", pmon.fps_min, pmon.fps_max, pmon.fps_avg);
+		printf("CPU min: %6.1f%% max: %6.1f%% avg: %6.1f%%\n", pmon.cpu_min, pmon.cpu_max, pmon.cpu_avg);
+		printf("\n");
+	}
+#else
+	printf("FPS: %6.1f\n", pmon.fps_cur);
+	if (print_detailed_stats) {
+		printf("FPS min: %6.1f  max: %6.1f  avg: %6.1f\n", pmon.fps_min, pmon.fps_max, pmon.fps_avg);
+		printf("\n");
+	}
+#endif
+}

--- a/src/plugin_lib/perfmon.h
+++ b/src/plugin_lib/perfmon.h
@@ -1,0 +1,41 @@
+/***************************************************************************
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02111-1307 USA.           *
+ ***************************************************************************/
+
+/*
+ * FPS & CPU-usage monitoring
+ *
+ * Added November 2016 by senquack (Daniel Silsby)
+ */
+
+#ifndef PERFMON_H
+#define PERFMON_H
+
+// Called when (re)starting a game, before first call to pmonUpdate()
+void pmonReset();
+
+// Called once per frame, updating the stats.
+// Returns true if new stats were generated.
+bool pmonUpdate();
+
+// Output stats to console
+void pmonPrintStats(bool print_detailed_stats);
+
+// Called when pausing emu and entering frontend, or vice versa
+void pmonPause();
+void pmonResume();
+
+#endif //PERFMON_H

--- a/src/port/caanoo/port.cpp
+++ b/src/port/caanoo/port.cpp
@@ -2,6 +2,7 @@
 #include "port.h"
 #include "r3000a.h"
 #include "plugins.h"
+#include "plugin_lib/perfmon.h"  // FPS / CPU performance monitoring
 #include "wiz_lib.h"
 #include "profiler.h"
 
@@ -270,6 +271,13 @@ int main (int argc, char **argv)
 		}
 		if (strcmp(argv[i],"-adjust")==0) { PSXCLK=(u32)((double)PSXCLK*atof(argv[i+1])); }
 		
+		// Performance monitoring options
+		if (strcmp(argv[i],"-perfmon")==0) {
+			// Enable detailed stats and console output
+			Config.PerfmonConsoleOutput = true;
+			Config.PerfmonDetailedStats = true;
+		}
+
 		// GPU
 		if (strcmp(argv[i],"-framelimit")==0) { extern bool frameLimit; frameLimit=true; } // frames limit
 		if (strcmp(argv[i],"-skip")==0) { extern int skipCount; skipCount=atoi(argv[i+1]); } // frame skip (0,1,2,3...)
@@ -309,6 +317,7 @@ int main (int argc, char **argv)
 	}
 
 	psxReset();	
+	pmonReset(); // Reset performance monitor (FPS,CPU usage,etc)
 
 	if (cdrfilename[0]!='\0') { if (CheckCdrom() == -1) { printf("Failed checking ISO image.\n"); SetIsoFile(NULL); }
 	else { if (LoadCdrom() == -1) { printf("Failed loading ISO image.\n"); SetIsoFile(NULL); } } }

--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -6,6 +6,7 @@
 #include "port.h"
 #include "r3000a.h"
 #include "plugins.h"
+#include "plugin_lib/perfmon.h"  // FPS / CPU performance monitoring
 #include "profiler.h"
 #include <SDL.h>
 
@@ -14,7 +15,6 @@
 #include <limits.h>
 #endif
 
-//senquack
 #ifdef spu_pcsxrearmed
 #include "spu/spu_pcsxrearmed/spu_config.h"		// To set spu-specific configuration
 #endif
@@ -460,6 +460,7 @@ void pad_update(void)
 		sioSyncMcds();
 
 		emu_running = false;
+		pmonPause();   // Pause performance monitor
 		GameMenu();
 		emu_running = true;
 		pad1 |= (1 << DKEY_START);
@@ -475,6 +476,7 @@ void pad_update(void)
 		extern bool fb_dirty;
 		fb_dirty = true; // redraw screen
 #endif
+		pmonResume();   // Resume performance monitor
 	}
 #endif
 }
@@ -857,6 +859,13 @@ int main (int argc, char **argv)
 			Config.ForcedXAUpdates=0;
 		}
 
+		// Performance monitoring options
+		if (strcmp(argv[i],"-perfmon")==0) {
+			// Enable detailed stats and console output
+			Config.PerfmonConsoleOutput = true;
+			Config.PerfmonDetailedStats = true;
+		}
+
 		// GPU
 	#ifdef gpu_dfxvideo
 		if (strcmp(argv[i],"-showfps")==0) { dfx_show_fps=true; } // show FPS
@@ -1029,6 +1038,7 @@ int main (int argc, char **argv)
 	emu_running = true;
 
 	psxReset();
+	pmonReset(); // Reset performance monitor (FPS,CPU usage,etc)
 
 	if (cdrfilename[0] != '\0') {
 		if (CheckCdrom() == -1) {

--- a/src/port/wiz/port.cpp
+++ b/src/port/wiz/port.cpp
@@ -2,6 +2,7 @@
 #include "port.h"
 #include "r3000a.h"
 #include "plugins.h"
+#include "plugin_lib/perfmon.h"  // FPS / CPU performance monitoring
 #include "wiz_lib.h"
 #include "profiler.h"
 
@@ -271,6 +272,13 @@ int main (int argc, char **argv)
 		}
 		if (strcmp(argv[i],"-adjust")==0) { PSXCLK=(u32)((double)PSXCLK*atof(argv[i+1])); }
 		
+		// Performance monitoring options
+		if (strcmp(argv[i],"-perfmon")==0) {
+			// Enable detailed stats and console output
+			Config.PerfmonConsoleOutput = true;
+			Config.PerfmonDetailedStats = true;
+		}
+
 		// GPU
 		if (strcmp(argv[i],"-framelimit")==0) { extern bool frameLimit; frameLimit=true; } // frames to wait
 		if (strcmp(argv[i],"-skip")==0) { extern int skipCount; skipCount=atoi(argv[i+1]); } // frame skip (0,1,2,3...)
@@ -309,6 +317,7 @@ int main (int argc, char **argv)
 	}
 
 	psxReset();	
+	pmonReset(); // Reset performance monitor (FPS,CPU usage,etc)
 
 	if (cdrfilename[0]!='\0') { if (CheckCdrom() == -1) { printf("Failed checking ISO image.\n"); SetIsoFile(NULL); }
 	else { if (LoadCdrom() == -1) { printf("Failed loading ISO image.\n"); SetIsoFile(NULL); } } }

--- a/src/psxcommon.h
+++ b/src/psxcommon.h
@@ -100,6 +100,10 @@ typedef struct {
 	//           than they'd normally be issued when SPU's XA buffer is not
 	//           full. This fixes droupouts in music/speech on slow devices.
 	boolean ForcedXAUpdates; 
+
+	// Options for performance monitor
+	boolean PerfmonConsoleOutput;
+	boolean PerfmonDetailedStats;
 } PcsxConfig;
 
 extern PcsxConfig Config;

--- a/src/psxcounters.cpp
+++ b/src/psxcounters.cpp
@@ -49,6 +49,7 @@
 #include "psxevents.h"
 #include "gpu.h"
 #include "profiler.h"
+#include "plugin_lib/perfmon.h"
 
 /******************************************************************************/
 
@@ -384,6 +385,9 @@ void psxRcntUpdate()
             HW_GPU_STATUS &= ~PSXGPU_LCF;
             setIrq( 0x01 );
             GPU_updateLace();
+
+            pmonUpdate();  // Update and display performance stats
+
             pad_update();
 
 #ifdef spu_pcsxrearmed


### PR DESCRIPTION
New performance monitor provides accurate FPS reporting no matter what GPU plugin is in use.
This will aid optimization and eventually fix erroneous FPS reported by GPU Unai.

TODO: Make OSD FPS reporting use this feature