### PR TITLE
Makefile.linux, Makefile.win32: Use more accurate 'gte_pcsx' GTE plugin

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -15,8 +15,9 @@ SPU    = spu_pcsxrearmed
 INTERPRETER = interpreter_pcsx
 #INTERPRETER = interpreter_new
 
-#GTE   = gte_pcsx
-GTE    = gte_new
+# Note: 'gte_new' causes lighting problems in dark areas of Silent Hill
+GTE   = gte_pcsx
+#GTE    = gte_new
 
 RM     = rm -f
 MD     = mkdir

--- a/Makefile.win32
+++ b/Makefile.win32
@@ -15,8 +15,9 @@ SPU    = spu_pcsxrearmed
 INTERPRETER = interpreter_pcsx
 #INTERPRETER = interpreter_new
 
-#GTE   = gte_pcsx
-GTE    = gte_new
+# Note: 'gte_new' causes lighting problems in dark areas of Silent Hill
+GTE   = gte_pcsx
+#GTE    = gte_new
 
 RM     = rm -f
 MD     = mkdir


### PR DESCRIPTION
Fixes lighting in dark areas of Silent Hill, possibly fixes
issues in other games.