### PR TITLE
Dynarec work

### DIFF
--- a/src/plugin_lib/perfmon.cpp
+++ b/src/plugin_lib/perfmon.cpp
@@ -100,12 +100,13 @@ void pmonReset()
 {
 	pmon.frame_ctr = 0;
 	pmon.fps_cur = 0;
-	pmon.tv_last.tv_sec = pmon.tv_last.tv_usec = 0;
 	memset(&pmon.buf, 0, sizeof(pmon.buf));
+
 #ifdef PERFMON_CPU_STATS
 	pmon.cpu_cur = 0;
 	pmonInitCpuUsage();
 #endif
+	gettimeofday(&pmon.tv_last, 0);
 }
 
 bool pmonUpdate()
@@ -118,7 +119,7 @@ bool pmonUpdate()
 
 	if (diff >= 1000000) {
 		ret = true;
-		pmon.fps_cur = (float)(1000000 * pmon.frame_ctr) / (float)diff;
+		pmon.fps_cur = 1000000.0f * (float)pmon.frame_ctr / (float)diff;
 #ifdef PERFMON_CPU_STATS
 		pmon.cpu_cur = pmonGetCpuUsage(diff);
 #endif

--- a/src/recompiler/mips/mips_codegen.h
+++ b/src/recompiler/mips/mips_codegen.h
@@ -123,6 +123,12 @@ do { \
 #define LW(rt, rn, imm) \
 	write32(0x8c000000 | ((rn) << 21) | ((rt) << 16) | ((imm) & 0xffff))
 
+#define LB(rt, rn, imm) \
+	write32(0x80000000 | ((rn) << 21) | ((rt) << 16) | ((imm) & 0xffff))
+
+#define LBU(rt, rn, imm) \
+	write32(0x90000000 | ((rn) << 21) | ((rt) << 16) | ((imm) & 0xffff))
+
 #define LH(rt, rn, imm) \
 	write32(0x84000000 | ((rn) << 21) | ((rt) << 16) | ((imm) & 0xffff))
 

--- a/src/recompiler/mips/mips_codegen.h
+++ b/src/recompiler/mips/mips_codegen.h
@@ -92,6 +92,19 @@ typedef enum {
 
 #define off(field)	offsetof(psxRegisters, field)
 
+
+/* ADR_HI, ADR_LO are the equivalents of MIPS GAS %hi(), %lo()
+ * They are always used as a pair, and allow converting an address to an
+ * upper/lower pair, with lower half interpreted as a signed offset.
+ * The upper half is adjusted when lower half of orig addr is > 0x7fff.
+ */
+#define ADR_HI(adr) \
+	(((uptr)(adr) & 0x8000) ? (((uptr)(adr) + 0x10000) >> 16) : ((uptr)(adr) >> 16))
+
+#define ADR_LO(adr) \
+	((uptr)(adr) & 0xffff)
+
+
 #define write32(i) \
 	do { *recMem++ = (u32)(i); } while (0)
 

--- a/src/recompiler/mips/rec_bcu.cpp.h
+++ b/src/recompiler/mips/rec_bcu.cpp.h
@@ -330,8 +330,16 @@ static void recBLTZAL()
 
 	rec_recompile_end_part1();
 	regClearBranch();
-	ORI(MIPSREG_V0, TEMP_1, (bpc & 0xffff)); // Block retval $v0 = branch-taken PC val
-	LI32(TEMP_2, nbpc);
+
+	if ((bpc >> 16) == (nbpc >> 16)) {
+		// Both PCs share an upper half, can save an instruction:
+		ORI(TEMP_2, TEMP_1, (nbpc & 0xffff));
+		ORI(MIPSREG_V0, TEMP_1, (bpc & 0xffff)); // Block retval $v0 = branch-taken PC val
+	} else {
+		ORI(MIPSREG_V0, TEMP_1, (bpc & 0xffff)); // Block retval $v0 = branch-taken PC val
+		LI32(TEMP_2, nbpc);
+	}
+
 	SW(TEMP_2, PERM_REG_1, offGPR(31));
 	rec_recompile_end_part2();
 
@@ -365,8 +373,16 @@ static void recBGEZAL()
 
 	rec_recompile_end_part1();
 	regClearBranch();
-	ORI(MIPSREG_V0, TEMP_1, (bpc & 0xffff)); // Block retval $v0 = branch-taken PC val
-	LI32(TEMP_2, nbpc);
+
+	if ((bpc >> 16) == (nbpc >> 16)) {
+		// Both PCs share an upper half, can save an instruction:
+		ORI(TEMP_2, TEMP_1, (nbpc & 0xffff));
+		ORI(MIPSREG_V0, TEMP_1, (bpc & 0xffff)); // Block retval $v0 = branch-taken PC val
+	} else {
+		ORI(MIPSREG_V0, TEMP_1, (bpc & 0xffff)); // Block retval $v0 = branch-taken PC val
+		LI32(TEMP_2, nbpc);
+	}
+
 	SW(TEMP_2, PERM_REG_1, offGPR(31));
 	rec_recompile_end_part2();
 

--- a/src/recompiler/mips/rec_lsu.cpp.h
+++ b/src/recompiler/mips/rec_lsu.cpp.h
@@ -843,7 +843,7 @@ static void gen_SWL_SWR(int count)
 	icount = count;
 	u32 *backpatch_label_exit_1 = 0;
 
-	LW(TEMP_3, PERM_REG_1, off(reserved)); // load addr of code block ptr array
+	LUI(TEMP_3, ADR_HI(recRAM)); // temp_3 = upper code block ptr array addr
 	do {
 		u32 opcode = *(u32 *)((char *)PSXM(PC));
 		s32 imm = _fImm_(opcode);
@@ -869,7 +869,7 @@ static void gen_SWL_SWR(int count)
 			// NOTE: Branch delay slot will contain the instruction below
 		}
 		// Important: this should be the last instruction in the loop (is BD slot of exit branch)
-		SW(0, TEMP_1, 0);  // set code block ptr to NULL
+		SW(0, TEMP_1, ADR_LO(recRAM));  // set code block ptr to NULL
 
 		PC += 4;
 

--- a/src/recompiler/mips/rec_lsu.cpp.h
+++ b/src/recompiler/mips/rec_lsu.cpp.h
@@ -370,7 +370,10 @@ static void StoreToAddr(int count)
 			ADDIU(MIPSREG_A0, r1, imm);
 		}
 		EXT(TEMP_1, MIPSREG_A0, 0, 0x15); // and 0x1fffff
-		INS(TEMP_1, 0, 0, 2); // clear 2 lower bits
+		if ((opcode & 0xfc000000) != 0xac000000) {
+			// Not a SW, clear lower 2 bits to ensure addr is aligned:
+			INS(TEMP_1, 0, 0, 2);
+		}
 		ADDU(TEMP_1, TEMP_1, TEMP_3);
 
 		backpatch_label_exit_1 = 0;

--- a/src/recompiler/mips/rec_lsu.cpp.h
+++ b/src/recompiler/mips/rec_lsu.cpp.h
@@ -354,7 +354,7 @@ static void StoreToAddr(int count)
 
 	icount = count;
 	u32 *backpatch_label_exit_1 = 0;
-	LW(TEMP_3, PERM_REG_1, off(reserved));
+	LUI(TEMP_3, ADR_HI(recRAM)); // temp_3 = upper code block ptr array addr
 	do {
 		u32 opcode = *(u32 *)((char *)PSXM(PC));
 		s32 imm = _fImm_(opcode);
@@ -381,7 +381,7 @@ static void StoreToAddr(int count)
 			// NOTE: Branch delay slot will contain the instruction below
 		}
 		// Important: this should be the last opcode in the loop (see note above)
-		SW(0, TEMP_1, 0);
+		SW(0, TEMP_1, ADR_LO(recRAM));  // set code block ptr to NULL
 
 		PC += 4;
 

--- a/src/recompiler/mips/recompiler.cpp
+++ b/src/recompiler/mips/recompiler.cpp
@@ -135,7 +135,6 @@ disasm_label stub_labels[] =
   make_stub_label(psxMemWrite8),
   make_stub_label(psxMemWrite16),
   make_stub_label(psxMemWrite32),
-  make_stub_label(psxMemWrite32_error),
   make_stub_label(psxHwRead8),
   make_stub_label(psxHwRead16),
   make_stub_label(psxHwRead32),
@@ -143,7 +142,6 @@ disasm_label stub_labels[] =
   make_stub_label(psxHwWrite16),
   make_stub_label(psxHwWrite32),
   make_stub_label(psxException),
-  make_stub_label(psxBranchTest_rec)
 };
 
 const u32 num_stub_labels = sizeof(stub_labels) / sizeof(disasm_label);

--- a/src/recompiler/mips/recompiler.cpp
+++ b/src/recompiler/mips/recompiler.cpp
@@ -68,9 +68,9 @@ static u32 psxRecLUT[0x010000];
 #define REC_MAX_OPCODES		80
 
 static u8 recMemBase[RECMEM_SIZE + (REC_MAX_OPCODES*2) + 0x4000] __attribute__ ((__aligned__ (32)));
-static u32 *recMem;				/* the recompiled blocks will be here */
-static s8 recRAM[0x200000];			/* and the ptr to the blocks here */
-static s8 recROM[0x080000];			/* and here */
+static u32 *recMem; /* the recompiled blocks will be here */
+static s8 recRAM[0x200000] __attribute__((aligned(4))); /* and the ptr to the blocks here */
+static s8 recROM[0x080000] __attribute__((aligned(4))); /* and here */
 static u32 pc;					/* recompiler pc */
 static u32 oldpc;
 static u32 branch = 0;
@@ -191,8 +191,6 @@ void clear_insn_cache(void *start, void *end, int flags)
 
 static void recRecompile()
 {
-	psxRegs.reserved = (void *)recRAM;
-
 	if ((u32)recMem - (u32)recMemBase >= RECMEM_SIZE_MAX )
 		recReset();
 


### PR DESCRIPTION
Work on load/store code emitters:
- Optimized lower-8MB address check, combined with using the effective address checked in first iteration of op loops
- ADR_HI()/ADR_LO() macro equivalents of GNU GAS %hi, %ho allow more efficient addressing
- Add code block invalidation to SWL/SWR code emitter, to fix Valkyrie Profile segfault at start (unfortunately game crashes later due to GPU bugs even with interpreter)
- Optimize LWL/LWR/SWL/SWR array lookups and code
- No need to align dst address when SW invalidates code block ptr
- No need to use psxRegs.reserved for recRAM[] base ptr.. ADR_HI()/ADR_LO() lets it be done just as fast or faster
- Align recRAM[], recROM[] to 4 bytes since they're char arrays and compiler might not

Work on branches:
- Emitters for Jump-and-link and Branch-and-link save an instruction loading PCs when possible

MISC:
- Fixed 'perfmon' not reliably showing performance stats until menu is entered/exited.


