### PR TITLE
Psxevents and sstate work

### DIFF
--- a/src/cdrom.cpp
+++ b/src/cdrom.cpp
@@ -226,29 +226,29 @@ u16 calcCrc(const u8 *d, const int len) {
 
 // cdrInterrupt
 #define CDR_INT(eCycle) { \
-	psxEventQueue.enqueue(PSXINT_CDR, eCycle); \
+	psxEvqueueAdd(PSXINT_CDR, eCycle); \
 }
 
 // cdrReadInterrupt
 #define CDREAD_INT(eCycle) { \
-	psxEventQueue.enqueue(PSXINT_CDREAD, eCycle); \
+	psxEvqueueAdd(PSXINT_CDREAD, eCycle); \
 }
 
 //senquack - Next two interrupt macros are new from PCSX Reloaded/Rearmed.
 // cdrLidSeekInterrupt
 #define CDRLID_INT(eCycle) { \
-	psxEventQueue.enqueue(PSXINT_CDRLID, eCycle); \
+	psxEvqueueAdd(PSXINT_CDRLID, eCycle); \
 }
 
 // cdrPlayInterrupt
 #define CDRMISC_INT(eCycle) { \
-	psxEventQueue.enqueue(PSXINT_CDRPLAY, eCycle); \
+	psxEvqueueAdd(PSXINT_CDRPLAY, eCycle); \
 }
 
 #define StopReading() { \
 	if (cdr.Reading) { \
 		cdr.Reading = 0; \
-		psxEventQueue.dequeue(PSXINT_CDREAD); \
+		psxEvqueueRemove(PSXINT_CDREAD); \
 	} \
 	cdr.StatP &= ~(STATUS_READ|STATUS_SEEK);\
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -47,11 +47,6 @@
 char CdromId[10] = "";
 char CdromLabel[33] = "";
 
-int toSaveState=0;
-int toLoadState=0;
-int toExit=0;
-char *SaveState_filename=NULL;
-
 /* PSX Executable types */
 #define PSX_EXE     1
 #define CPE_EXE     2

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -859,6 +859,9 @@ int LoadState(const char *file) {
 	//      of 'SaveVersion' variable for explanation.
 	if (version <= 0x8b410004) {
 		printf("Warning: using buggy older savestate version, expect problems.\n");
+		// Even though no rcnt data is available to load, root counter
+		//  still needs a hacked kick in the pants to get started.
+		psxRcntFreezeLoadHack();
 		goto skip_missing_data_hack;
 	}
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -404,6 +404,9 @@ int CheckCdrom() {
 		if (CdromId[2] == 'e' || CdromId[2] == 'E')
 			Config.PsxType = PSX_TYPE_PAL; // pal
 		else Config.PsxType = PSX_TYPE_NTSC; // ntsc
+
+		// Should be called when Config.PsxType changes
+		SPU_resetUpdateInterval();
 	}
 
 	if (CdromLabel[0] == ' ') {
@@ -812,7 +815,7 @@ int LoadState(const char *file) {
 	// saved contents of psxRegs.interrupt and psxRegs.intCycle[]
 	// NOTE: important to do this before calling any functions like
 	// psxRcntFreeze() that will queue events of their own.
-	psxEventQueue.init_from_freeze();
+	psxEvqueueInitFromFreeze();
 
 	if (Config.HLE)
 		psxBiosFreeze(0);

--- a/src/misc.h
+++ b/src/misc.h
@@ -72,10 +72,6 @@ extern int Load(const char *ExePath);
 extern int SaveState(const char *file);
 extern int LoadState(const char *file);
 extern int CheckState(const char *file);
-extern int toSaveState;
-extern int toLoadState;
-extern int toExit;
-extern char *SaveState_filename;
 
 extern bool FileExists(const char* filename);
 #endif /* __MISC_H__ */

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -72,34 +72,6 @@ void ReleasePlugins(void) {
 	SPU_shutdown();
 }
 
-//senquack - UpdateSPU() provides a void(void) function that wraps
-// call to SPU_async(), allowing generic handling of event handlers
-// in r3000a.cpp psxBranchTest()
-void UpdateSPU(void)
-{
-#ifdef spu_pcsxrearmed
-	//Clear any scheduled SPUIRQ, as HW SPU IRQ will end up handled with
-	// this call to SPU_async(), and new SPUIRQ scheduled if necessary.
-	psxEventQueue.dequeue(PSXINT_SPUIRQ);
-
-	SPU_async(psxRegs.cycle, 1);
-#else
-	SPU_async();
-#endif
-	SCHEDULE_SPU_UPDATE(spu_upd_interval);
-}
-
-//senquack - HandleSPU_IRQ() provides a void(void) function that wraps
-// call to SPU_async(), allowing generic handling of event handlers
-// in r3000a.cpp psxBranchTest(). NOTE: Only spu_pcsxrearmed actually
-// implements handling of SPU HW IRQs.
-void HandleSPU_IRQ(void)
-{
-#ifdef spu_pcsxrearmed
-	SPU_async(psxRegs.cycle, 0);
-#endif
-}
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -119,7 +91,7 @@ void CALLBACK Trigger_SPU_IRQ(void) {
 //  Need for Speed 3, Metal Gear Solid, Chrono Cross, etc. and is currently
 //  only implemented in spu_pcsxrearmed)
 void CALLBACK Schedule_SPU_IRQ(unsigned int cycles_after) {
-	psxEventQueue.enqueue(PSXINT_SPUIRQ, cycles_after);
+	psxEvqueueAdd(PSXINT_SPUIRQ, cycles_after);
 }
 
 #ifdef __cplusplus

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -135,20 +135,12 @@ extern void SPU_playCDDAchannel(unsigned char *, int);
 #endif
 
 //senquack - added these two functions, see notes in plugins.cpp
-void UpdateSPU(void);
-void HandleSPU_IRQ(void);
-
-//senquack - added these two functions, see notes in plugins.cpp
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void CALLBACK Trigger_SPU_IRQ(void);
 void CALLBACK Schedule_SPU_IRQ(unsigned int cycles_after);
-
-#define SCHEDULE_SPU_UPDATE(eCycle) { \
-	psxEventQueue.enqueue(PSXINT_SPU_UPDATE, eCycle); \
-}
 
 #ifdef __cplusplus
 }

--- a/src/port/sdl/frontend.cpp
+++ b/src/port/sdl/frontend.cpp
@@ -456,14 +456,39 @@ static MENU gui_MainMenu = { MENU_SIZE, 0, 112, 120, (MENUITEM *)&gui_MainMenuIt
 
 static int gui_state_load()
 {
-	state_load();
+	if (state_load() < 0) {
+		// Load failure
+		// TODO: Add user interaction to handle gracefully, improve interface
+		return 0;
+	}
 
 	return 1;
 }
 
 static int gui_state_save()
 {
-	state_save();
+	video_clear();
+	port_printf(160-(6*8/2), 120-(8/2), "SAVING");
+	video_flip();
+
+	if (state_save() < 0) {
+		// Error saving
+
+		for (;;) {
+			u32 keys = key_read();
+			video_clear();
+			// check keys
+			if (keys) {
+				key_reset();
+				return 0;
+			}
+
+			port_printf(160-(11*8/2), 120-12, "SAVE FAILED");
+			port_printf(160-(18*8/2), 120+12, "Out of disk space?");
+			video_flip();
+			timer_delay(75);
+		}
+	}
 
 	return 1;
 }

--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -301,20 +301,23 @@ void config_save()
 	free(config);
 }
 
-void state_load()
+// Returns 0: success, -1: failure
+int state_load()
 {
 	char savename[512];
 	sprintf(savename, "%s/%s.%d.sav", sstatesdir, CdromId, saveslot);
 	if (FileExists(savename)) {
-		LoadState(savename);
+		return LoadState(savename);
 	}
+	return -1;
 }
 
-void state_save()
+// Returns 0: success, -1: failure
+int state_save()
 {
 	char savename[512];
 	sprintf(savename, "%s/%s.%d.sav", sstatesdir, CdromId, saveslot);
-	SaveState(savename);
+	return SaveState(savename);
 }
 
 static struct {

--- a/src/port/sdl/port.h
+++ b/src/port/sdl/port.h
@@ -44,8 +44,8 @@ extern void port_mute(void);
 
 extern unsigned short *SCREEN;
 
-void state_load();
-void state_save();
+int state_load();
+int state_save();
 
 int SelectGame();
 int GameMenu();

--- a/src/psxcounters.cpp
+++ b/src/psxcounters.cpp
@@ -27,14 +27,7 @@
 // * Proper handling of counter overflows.
 // * VBlank root counter (counter 3) is triggered only as often as needed,
 //   not every HSync.
-// * Because SPU was originally updated inside VBlank root counter code, the
-//   above change necessitated moving SPU update handling to psxBranchTest()
-//   in r3000a.cpp. In PCSX Rearmed, Notaz's SPU plugin requires an update
-//   only once per emulated frame, but we target slower devices and until
-//   we get good auto-frameskip, more-frequent SPU updates are necessary.
-//   Older SPU plugins required *much* more frequent updates, making it even
-//   less practical to do SPU updates here now that psxRcntUpdate() here is
-//   called so much less frequently.
+// * SPU updates occur using new event queue (psxevents.cpp)
 // * Some optimizations, more accurate calculation of timer updates.
 //
 // TODO : Implement direct rootcounter mem access of Rearmed dynarec?
@@ -77,36 +70,25 @@ enum
     RcUnknown15       = 0x8000, // 15   ? (always zero)
 };
 
-#define CounterQuantity           ( 4 )
-//static const u32 CounterQuantity  = 4;
-
+static const u32 CounterQuantity  = 4;
 static const u32 CountToOverflow  = 0;
 static const u32 CountToTarget    = 1;
 
-static const u32 FrameRate[]      = { 60, 50 };
+const u32 FrameRate[2] = { 60, 50 };
 
 //senquack - Originally {262,312}, updated to match Rearmed:
-static const u32 HSyncTotal[]     = { 263, 313 };
+const u32 HSyncTotal[2] = { 263, 313 };
 
 //senquack - TODO: PCSX Reloaded uses {243,256} here, and Rearmed
 // does away with array completely and uses 240 in all cases:
 //static const u32 VBlankStart[]    = { 240, 256 };
-#define VBlankStart 240
-
-//Cycles between SPU plugin updates
-u32 spu_upd_interval;
-
-#ifndef spu_pcsxrearmed
-// Older SPU plugins are updated every 23rd HSync, regardless of PAL/NTSC mode
-#define SPU_UPD_INTERVAL 23
-#endif
+static const u32 VBlankStart = 240;
 
 /******************************************************************************/
 
 static Rcnt rcnts[ CounterQuantity ];
 
 u32 hSyncCount = 0;
-static u32 spuSyncCount = 0;
 
 //senquack - Added two vars from PCSX Rearmed:
 u32 frame_counter = 0;
@@ -115,8 +97,8 @@ static u32 base_cycle = 0;
 
 //senquack - Originally separate variables, now handled together with
 // all other scheduled emu events as new event type PSXINT_RCNT
-static u32 &psxNextCounter = psxRegs.intCycle[PSXINT_RCNT].cycle;
-static u32 &psxNextsCounter = psxRegs.intCycle[PSXINT_RCNT].sCycle;
+#define psxNextCounter psxRegs.intCycle[PSXINT_RCNT].cycle
+#define psxNextsCounter psxRegs.intCycle[PSXINT_RCNT].sCycle
 
 /******************************************************************************/
 
@@ -264,7 +246,7 @@ static void psxRcntSet(void)
     }
 
     // Any previously queued PSXINT_RCNT event will be replaced
-    psxEventQueue.enqueue(PSXINT_RCNT, psxNextCounter);
+    psxEvqueueAdd(PSXINT_RCNT, psxNextCounter);
 }
 
 /******************************************************************************/
@@ -359,7 +341,6 @@ void psxRcntUpdate()
     // rcnt base.
     if( cycle - rcnts[3].cycleStart >= rcnts[3].cycle )
     {
-        // TODO (senquack): Implement HW_GPU_STATUS code from Rearmed
         u32 leftover_cycles = cycle - rcnts[3].cycleStart - rcnts[3].cycle;
         u32 next_vsync;
 
@@ -384,8 +365,7 @@ void psxRcntUpdate()
             //senquack - PCSX Rearmed updates its SPU plugin once per emulated
             // frame. However, we target slower platforms like GCW Zero, and
             // lack auto-frameskip, so this would lead to audio dropouts. For
-            // now, we update SPU plugin twice per frame in r3000a.cpp
-            // psxBranchTest()
+            // now, we update SPU plugin twice per frame in psxevents.cpp
             //SPU_async( cycle, 1 );
 #endif
         }
@@ -543,22 +523,6 @@ void psxRcntInit(void)
     hSyncCount = 0;
     hsync_steps = 1;
 
-    // SPU interval handling:
-#ifdef spu_pcsxrearmed
-    // PCSX Rearmed only updates SPU once per frame, but we target platforms like
-    //  GCW Zero that are too slow to run many games at 60FPS. Until we have good
-    //  auto-frameskip, we update SPU plugin twice per frame to avoid dropouts.
-	//  If this interval is changed, be sure to check cutscenes in Metal Gear
-	//  Solid or the intro to Chrono Cross, as they use SPU HW IRQ and are highly
-	//  sensitive to timing.
-    spu_upd_interval = PSXCLK / (FrameRate[Config.PsxType] * 2);
-#else
-    // Older SPU plugins are updated much more often than above
-    spu_upd_interval = (SPU_UPD_INTERVAL * PSXCLK) / (FrameRate[Config.PsxType] * HSyncTotal[Config.PsxType]);
-#endif
-    // Schedule first SPU update. Future ones will be scheduled automatically
-    SCHEDULE_SPU_UPDATE(spu_upd_interval);
-
     psxRcntSet();
 }
 
@@ -566,7 +530,10 @@ void psxRcntInit(void)
 
 int psxRcntFreeze(void *f, FreezeMode mode)
 {
+	// Old cruft left from when SPU was updated by psxcounters code,
+	//  now this is 0 placeholder to maintain savestate compatibilty
     u32 spuSyncCount = 0;
+
     u32 count;
     s32 i;
 
@@ -595,12 +562,8 @@ int psxRcntFreeze(void *f, FreezeMode mode)
     return 0;
 }
 
-unsigned psxGetSpuSync(void){
-	return spuSyncCount;
-}
-
-//senquack - Called before psxRegs.cycle is adjusted back to zero
-// by psxResetCycleValue() in psxevents.cpp
+// Called before psxRegs.cycle is adjusted back to zero
+//  by PSXINT_RESET_CYCLE_VAL event in psxevents.cpp
 void psxRcntAdjustTimestamps(const uint32_t prev_cycle_val)
 {
 	for (int i=0; i < CounterQuantity; ++i) {

--- a/src/psxcounters.cpp
+++ b/src/psxcounters.cpp
@@ -383,22 +383,6 @@ void psxRcntUpdate()
 #ifdef USE_GPULIB
             GPU_vBlank( 0, HW_GPU_STATUS >> 31 );
 #endif
-
-			if ((toSaveState)&&(SaveState_filename)) {
-			toSaveState=0;
-			SaveState(SaveState_filename);
-			if (toExit)
-				pcsx4all_exit();
-			}
-			if ((toLoadState)&&(SaveState_filename))
-			{
-				toLoadState=0;
-				// Check for error
-				if (LoadState(SaveState_filename) != -1) {
-					psxCpu->Execute();
-					pcsx4all_exit();
-				}
-			}
         }
 
         // Schedule next call, in hsyncs

--- a/src/psxcounters.h
+++ b/src/psxcounters.h
@@ -28,7 +28,9 @@
 #include "plugins.h"
 
 extern u32 hSyncCount, frame_counter;
-extern u32 spu_upd_interval;
+
+extern const u32 FrameRate[2];
+extern const u32 HSyncTotal[2];
 
 typedef struct Rcnt
 {
@@ -50,9 +52,6 @@ extern u32 psxRcntRtarget(u32 index);
 
 extern int psxRcntFreeze(void* f, FreezeMode mode);
 
-extern unsigned psxGetSpuSync(void);
-
-// senquack - Called before psxRegs.cycle is adjusted back to zero
 void psxRcntAdjustTimestamps(const uint32_t prev_cycle_val);
 
 #endif /* __PSXCOUNTERS_H__ */

--- a/src/psxcounters.h
+++ b/src/psxcounters.h
@@ -52,6 +52,10 @@ extern u32 psxRcntRtarget(u32 index);
 
 extern int psxRcntFreeze(void* f, FreezeMode mode);
 
+// XXX: HACK December 2016
+//      See comments regarding save version 0x8b410004 in misc.cpp.
+extern void psxRcntFreezeLoadHack(void);
+
 void psxRcntAdjustTimestamps(const uint32_t prev_cycle_val);
 
 #endif /* __PSXCOUNTERS_H__ */

--- a/src/psxdma.h
+++ b/src/psxdma.h
@@ -29,29 +29,29 @@
 
 //senquack - NOTE: These macros have been updated to use new PSXINT_*
 // interrupts enum and intCycle struct (much cleaner than before)
-// from PCSX Reloaded/Rearmed as well as new event queue (psxevents.h)
+// from PCSX Reloaded/Rearmed as well as new event queue (psxEvqueues.h)
 #define GPUDMA_INT(eCycle) { \
-	psxEventQueue.enqueue(PSXINT_GPUDMA, eCycle); \
+	psxEvqueueAdd(PSXINT_GPUDMA, eCycle); \
 }
 
 #define SPUDMA_INT(eCycle) { \
-	psxEventQueue.enqueue(PSXINT_SPUDMA, eCycle); \
+	psxEvqueueAdd(PSXINT_SPUDMA, eCycle); \
 }
 
 #define MDECOUTDMA_INT(eCycle) { \
-	psxEventQueue.enqueue(PSXINT_MDECOUTDMA, eCycle); \
+	psxEvqueueAdd(PSXINT_MDECOUTDMA, eCycle); \
 }
 
 #define MDECINDMA_INT(eCycle) { \
-	psxEventQueue.enqueue(PSXINT_MDECINDMA, eCycle); \
+	psxEvqueueAdd(PSXINT_MDECINDMA, eCycle); \
 }
 
 #define GPUOTCDMA_INT(eCycle) { \
-	psxEventQueue.enqueue(PSXINT_GPUOTCDMA, eCycle); \
+	psxEvqueueAdd(PSXINT_GPUOTCDMA, eCycle); \
 }
 
 #define CDRDMA_INT(eCycle) { \
-	psxEventQueue.enqueue(PSXINT_CDRDMA, eCycle); \
+	psxEvqueueAdd(PSXINT_CDRDMA, eCycle); \
 }
 
 void psxDma2(u32 madr, u32 bcr, u32 chcr);

--- a/src/psxevents.cpp
+++ b/src/psxevents.cpp
@@ -16,9 +16,17 @@
  ***************************************************************************/
 
 /*
- * Event / interrupt scheduling
+ * Event / interrupt scheduler queue
  *
  * Added July 2016 by senquack (Daniel Silsby)
+ *
+ * Queue is an array sorted by event imminency. It can have spare capacity
+ * both at the front and at the back. If an event is removed from the front
+ * of the queue and a new event enqueued that ends up back at front of queue,
+ * the operation is O(1).
+ *
+ * We also handle a small bit of SPU update logic here
+ *
  */
 
 #include "psxevents.h"
@@ -30,197 +38,485 @@
 #include "psxdma.h"
 #include "mdec.h"
 
-// psxBranchTest() debug statistics
-#ifdef DEBUG_EVENTS
-unsigned int bt_necessary, bt_unnecessary;
+// When psxRegs.cycle is >= this figure, it gets reset to 0:
+static const u32 reset_cycle_val_at = 2000000000;
+
+#ifndef spu_pcsxrearmed
+// Older SPU plugins are updated every 23rd HSync, regardless of PAL/NTSC mode
+#define SPU_UPD_INTERVAL 23
 #endif
 
-// When psxRegs.cycle is >= this figure, it gets reset to 0:
-static const uint32_t reset_cycle_val_at = 2000000000;
+///////////////////////////
+// Internal helper funcs //
+///////////////////////////
+static void psxEvqueueResetCycleVal(void);
+static void psxEvqueueSchedulePersistentEvents(void);
+static void psxEvqueueAdjustTimestamps(u32 prev_cycle_val);
+
+/////////////////////
+// SPU event funcs //
+/////////////////////
+void SPU_resetUpdateInterval(void);
+static void SPU_update(void);
+static void SPU_handleIRQ(void);
+
+///////////////////////////////////
+// Internal queue implementation //
+///////////////////////////////////
+static const int EVQUEUE_CAPACITY = PSXINT_COUNT;
+
+typedef void (*EventFunc)(void);
+
+static struct {
+	u8 useBeginIdx;             // Index of first used element of storage[]
+	u8 useEndIdx;               // One past last used index of storage[], or
+	                            //  same val as useBeginIdx when queue is empty.
+	u8 queue[EVQUEUE_CAPACITY];
+
+	EventFunc funcs[EVQUEUE_CAPACITY];
+
+	u32 spuUpdateInterval;      // Cycles between SPU plugin updates
+} evqueue;
+
+// Unimplemented events call this (shouldn't happen)
+static void EventStubFunc(void)
+{
+}
+
+static inline bool EventMoreImminent(u8 lh_ev, u8 rh_ev);
+static inline void evqueueClear(void);
+static inline size_t evqueueSize(void);
+static inline bool evqueueEmpty(void);
+static inline u8 evqueueFront(void);
+static inline u8* evqueueFrontPtr(void);
+static inline u8* evqueueEndPtr(void);
+static inline void evqueueAdd(u8 ev);
+static inline bool evqueueRemove(u8 ev);
+static inline void evqueueRemoveFront(void);
+static inline void evqueueMoveForward(u8 *start, u8 *end);
+static inline void evqueueMoveBackward(u8 *start, u8 *end);
+static inline void evqueueInsertFront(u8 *it, u8 ev);
+static inline void evqueueInsertBack(u8 *it, u8 ev);
+#ifdef DEBUG_EVENTS
+static bool evqueueConsistencyCheck(void);
+static void evqueuePrintQueue(void);
+#endif
+
+void psxEvqueueInit(void)
+{
+	evqueue.funcs[PSXINT_SIO]             = sioInterrupt;
+	evqueue.funcs[PSXINT_CDR]             = cdrInterrupt;
+	evqueue.funcs[PSXINT_CDREAD]          = cdrReadInterrupt;
+	evqueue.funcs[PSXINT_GPUDMA]          = gpuInterrupt;
+	evqueue.funcs[PSXINT_MDECOUTDMA]      = mdec1Interrupt;
+	evqueue.funcs[PSXINT_SPUDMA]          = spuInterrupt;
+	evqueue.funcs[PSXINT_GPUBUSY]         = EventStubFunc;         // STUB-UNIMPLEMENTED (TODO?)
+	evqueue.funcs[PSXINT_MDECINDMA]       = mdec0Interrupt;
+	evqueue.funcs[PSXINT_GPUOTCDMA]       = gpuotcInterrupt;
+	evqueue.funcs[PSXINT_CDRDMA]          = cdrDmaInterrupt;
+	evqueue.funcs[PSXINT_NEWDRC_CHECK]    = EventStubFunc;         // STUB-UNIMPLEMENTED (TODO?)
+	evqueue.funcs[PSXINT_RCNT]            = psxRcntUpdate;
+	evqueue.funcs[PSXINT_CDRLID]          = cdrLidSeekInterrupt;
+	evqueue.funcs[PSXINT_CDRPLAY]         = cdrPlayInterrupt;
+	evqueue.funcs[PSXINT_SPUIRQ]          = SPU_handleIRQ;
+	evqueue.funcs[PSXINT_SPU_UPDATE]      = SPU_update;
+	evqueue.funcs[PSXINT_RESET_CYCLE_VAL] = psxEvqueueResetCycleVal;
+	evqueue.funcs[PSXINT_SIO_SYNC_MCD]    = sioSyncMcds;
+
+	evqueueClear();
+	psxEvqueueSchedulePersistentEvents();
+}
+
+// Rebuild event queue afresh from psxRegs.intCycle[] contents
+void psxEvqueueInitFromFreeze(void)
+{
+	evqueueClear();
+	for (int ev=0; ev < PSXINT_COUNT; ++ev)
+		if (psxRegs.interrupt & (1 << ev))
+			evqueueAdd((psxEventNum)ev);
+
+	psxEvqueueSchedulePersistentEvents();
+
+	// Don't trust io_cycle_counter from a freeze, as older savestate versions
+	//  from before event queue implementation may have invalid value.
+	psxRegs.io_cycle_counter = 0;
+	psxRegs.intCycle[PSXINT_NEXT_EVENT] = psxRegs.intCycle[evqueueFront()];
+}
 
 // Function called when PSXINT_RESET_CYCLE_VAL event occurs:
 // psxRegs.cycle is now regularly reset to 0 instead of being allowed to
 // overflow. This ensures that it can always be compared directly to
 // psxRegs.io_cycle_counter to know if psxBranchTest() needs to be called.
-static void psxResetCycleValue()
+static void psxEvqueueResetCycleVal(void)
 {
 #ifdef DEBUG_EVENTS
-    /* psxBranchTest() debug statistics */
-	printf("\n\nResetting cycle value %u  io_cycle_counter: %u\n", psxRegs.cycle, psxRegs.io_cycle_counter);
-	printf("bt_necessary: %u  bt_unnecessary: %u\n", bt_necessary, bt_unnecessary);
-	bt_necessary = bt_unnecessary = 0;
-	//printf("bt_cp0_irq_enable: %u  bt_cp0_irq_disable: %u\n", bt_cp0_irq_enable, bt_cp0_irq_disable);
-	//bt_cp0_irq_enable = bt_cp0_irq_disable = 0;
-	psxEventQueue.print_event_queue();
+	printf("\n------------------------------------------------------\n");
+	printf("%s() queue state on entry:\n", __func__);
+	evqueuePrintQueue();
 #endif
 
 	// Any events in the queue must be adjusted to match:
-	psxEventQueue.adjust_event_timestamps(psxRegs.cycle);
+	psxEvqueueAdjustTimestamps(psxRegs.cycle);
 
 	// All root-counter timestamps must also be adjusted:
 	psxRcntAdjustTimestamps(psxRegs.cycle);
 
 	// Reset cycle counter and enqueue new reset event:
 	psxRegs.cycle = 0;
-	psxEventQueue.enqueue(PSXINT_RESET_CYCLE_VAL, reset_cycle_val_at);
+	psxEvqueueAdd(PSXINT_RESET_CYCLE_VAL, reset_cycle_val_at);
 
 #ifdef DEBUG_EVENTS
-	psxEventQueue.print_event_queue();
+	printf("%s() queue state on exit:\n", __func__);
+	evqueuePrintQueue();
 	printf("io_cycle_counter: %u\n", psxRegs.io_cycle_counter);
-	printf("------------------------------------------\n\n");
+	printf("------------------------------------------------------\n\n");
 #endif
 }
 
-void EventQueue::schedule_persistent_events()
+static void psxEvqueueSchedulePersistentEvents(void)
 {
-	// Call psxResetCycleValue() once, which will take care of two things:
+	// Call psxEvqueueResetCycleVal() once, which will take care of two things:
 	//  1.) psxRegs.cycle value is reset to 0, important if loading a savestate
 	//      from an older version of emu, and psxRegs.cycle might be huge value
 	//  2.) schedule PSXINT_RESET_CYCLE_VAL event, which calls it again
 	//      at regular, very infrequent, intervals
-	psxResetCycleValue();
+	psxEvqueueResetCycleVal();
 
 	// Must schedule initial SPU update.. it will reschedule itself thereafter
-	SCHEDULE_SPU_UPDATE(spu_upd_interval);
+	SPU_resetUpdateInterval();
 }
 
-void EventQueue::enqueue(const psxEventType ev, const uint32_t cycles_after)
+// At very intermittent intervals, psxRegs.cycle is reset to 0 to prevent
+//  it from ever overflowing (simplifies checks against it elsewhere).
+//  This function fixes up timestamps of all queued events when this occurs.
+static void psxEvqueueAdjustTimestamps(u32 prev_cycle_val)
+{
+	for (u8 *ev = evqueueFrontPtr(); ev != evqueueEndPtr(); ++ev) {
+		psxRegs.intCycle[*ev].sCycle -= prev_cycle_val;
+	}
+
+	psxRegs.intCycle[PSXINT_NEXT_EVENT].sCycle -= prev_cycle_val;
+}
+
+void psxEvqueueAdd(psxEventNum ev, u32 cycles_after)
 {
 	// Dequeue event if it already exists, to match original emu behavior
-	if (contains(ev))
-		queue.remove(ev);
+	if (psxRegs.interrupt & (1 << ev))
+		evqueueRemove(ev);
 
-	psxRegs.interrupt |= (uint32_t)1 << ev;
+	psxRegs.interrupt |= (1 << ev);
 	psxRegs.intCycle[ev].sCycle = psxRegs.cycle;
 	psxRegs.intCycle[ev].cycle = cycles_after;
-	EventMoreImminent sort_functor; // Functor to sort queue entries by
-	queue.insert((uint8_t)ev, sort_functor);
-	psxRegs.intCycle[PSXINT_NEXT_EVENT] = psxRegs.intCycle[queue.front()];
+	evqueueAdd(ev);
+	psxRegs.intCycle[PSXINT_NEXT_EVENT] = psxRegs.intCycle[evqueueFront()];
 
-	// psxRegs.io_cycle_counter is used by interpreter/recompiler to determine
-	//  when next to call psxBranchTest()
-	psxRegs.io_cycle_counter = psxRegs.intCycle[PSXINT_NEXT_EVENT].sCycle + psxRegs.intCycle[PSXINT_NEXT_EVENT].cycle;
+	// io_cycle_counter is used to determine next time to call psxBranchTest()
+	psxRegs.io_cycle_counter = psxRegs.intCycle[PSXINT_NEXT_EVENT].sCycle +
+	                           psxRegs.intCycle[PSXINT_NEXT_EVENT].cycle;
 }
 
-void EventQueue::dequeue(const psxEventType ev)
+void psxEvqueueRemove(psxEventNum ev)
 {
-	if (!contains(ev))
+	if (!(psxRegs.interrupt & (1 << ev)))
 		return;
 
-	queue.remove(ev);
-	psxRegs.interrupt &= ~((uint32_t)1 << ev);
+	psxRegs.interrupt &= ~(1 << ev);
+	evqueueRemove(ev);
 
-	// If additional events were also scheduled, copy the next most-imminent
-	//  event's timestamp into PSXINT_NEXT_EVENT entry:
-	// (At least one event will always remain scheduled, i.e. PSXINT_RCNT
-	//  or PSXINT_SPU_UPDATE, so this check for emptiness is not really needed)
-	if (!queue.empty()) {
-		psxRegs.intCycle[PSXINT_NEXT_EVENT] = psxRegs.intCycle[queue.front()];
-
-		// io_cycle_counter is used by interpreter/recompiler to determine next
-		//  time to call psxBranchTest()
-		psxRegs.io_cycle_counter = psxRegs.intCycle[PSXINT_NEXT_EVENT].sCycle + psxRegs.intCycle[PSXINT_NEXT_EVENT].cycle;
-	} else {
-		// Shouldn't happen, but set to 0 just in case:
+#ifdef DEBUG_EVENTS
+	if (evqueueEmpty()) {
+		printf("ERROR: empty queue in %s()\n", __func__);
+		// Shouldn't happen, set to 0 for correctness's sake
 		psxRegs.io_cycle_counter = 0;
 	}
+#endif
+
+	// Copy next most-imminent event's timestamp into PSXINT_NEXT_EVENT entry.
+	//  At least one event will always remain in the queue, i.e. PSXINT_RCNT,
+	//  PSXINT_SPU_UPDATE, or PSXINT_RESET_CYCLE_VAL.
+	psxRegs.intCycle[PSXINT_NEXT_EVENT] = psxRegs.intCycle[evqueueFront()];
+
+	// io_cycle_counter is used to determine next time to call psxBranchTest()
+	psxRegs.io_cycle_counter = psxRegs.intCycle[PSXINT_NEXT_EVENT].sCycle +
+							   psxRegs.intCycle[PSXINT_NEXT_EVENT].cycle;
 }
 
-void EventQueue::dispatch_and_remove_front()
+// Called from psxBranchTest() when an event is due.
+void psxEvqueueDispatchAndRemoveFront(psxRegisters *pr)
 {
 #ifdef DEBUG_EVENTS
-	if (queue.empty()) {
-		printf("Error: EventQueue::dispatch_and_remove_front() called when queue is empty\n");
+	if (evqueueEmpty()) {
+		printf("ERROR: %s() called, but queue is empty\n", __func__);
 		return;
 	}
 #endif
 
-	uint8_t ev = queue.front();
-	queue.remove_front();
-	psxRegs.interrupt &= ~((uint32_t)1 << ev);
+	u8 ev = evqueueFront();
+	evqueueRemoveFront();
+	pr->interrupt &= ~(1 << ev);
 
 #ifdef DEBUG_EVENTS
-	if (eventFuncs[ev] == event_stub_func) {
-		printf("event_stub_func() called in EventQueue for unimplemented event %u\n", ev);
+	if (evqueue.funcs[ev] == EventStubFunc) {
+		printf("WARNING: EventStubFunc() called for unimplemented event %u\n", ev);
 	}
 #endif
 
-	eventFuncs[ev]();  // Dispatch event
+	evqueue.funcs[ev]();  // Dispatch event
 
 	// Queue can never be totally empty, as certain persistent events will
 	//  always be rescheduled during dispatch above.
 #ifdef DEBUG_EVENTS
-	if (queue.empty())
-		printf("ERROR: empty queue after EventQueue::dispatch_and_remove_front()\n");
+	if (evqueueEmpty())
+		printf("ERROR: empty queue in %s()\n", __func__);
 #endif
 
-	psxRegs.intCycle[PSXINT_NEXT_EVENT] = psxRegs.intCycle[queue.front()];
+	// Only set this after event is dispatched, as a new event could be
+	//  enqueued by the dispatched event.
+	pr->intCycle[PSXINT_NEXT_EVENT] = pr->intCycle[evqueueFront()];
+
+	// NOTE: Calling function, psxBranchTest(), will take care of setting
+	//  psxRegs.io_cycle_counter after all pending events are dispatched.
 }
 
-void EventQueue::init_from_freeze()
+// Should be called if Config.PsxType is changed
+void SPU_resetUpdateInterval(void)
 {
-	queue.clear();
-	EventMoreImminent sort_functor; // Functor to sort queue entries by
-	for (uint8_t i=0; i < PSXINT_COUNT; ++i) {
-		if (psxRegs.interrupt & ((uint32_t)1 << i)) {
-			queue.insert(i, sort_functor);
-		}
+#ifdef spu_pcsxrearmed
+	// PCSX Rearmed only updates SPU once per frame, but we target slower
+	//  platforms that might not run all games at 60FPS. Until we have good
+	//  auto-frameskip, we update SPU plugin twice per frame to avoid dropouts.
+	//  If this interval is changed, be sure to check cutscenes in Metal Gear
+	//  Solid or the intro to Chrono Cross, as they use SPU HW IRQ and are
+	//  highly sensitive to timing.
+	evqueue.spuUpdateInterval = PSXCLK / (FrameRate[Config.PsxType] * 2);
+#else
+	// Older SPU plugins are updated much more often than above
+	evqueue.spuUpdateInterval = (SPU_UPD_INTERVAL * PSXCLK) /
+		(FrameRate[Config.PsxType] * HSyncTotal[Config.PsxType]);
+#endif
+
+	psxEvqueueAdd(PSXINT_SPU_UPDATE, evqueue.spuUpdateInterval);
+}
+
+// SPU_update() is a wrapper function around SPU_async(),
+// allowing handling as a generic event
+static void SPU_update(void)
+{
+#ifdef spu_pcsxrearmed
+	//Clear any scheduled SPUIRQ, as HW SPU IRQ will end up handled with
+	// this call to SPU_async(), and new SPUIRQ scheduled if necessary.
+	psxEvqueueRemove(PSXINT_SPUIRQ);
+
+	SPU_async(psxRegs.cycle, 1);
+#else
+	SPU_async();
+#endif
+
+	psxEvqueueAdd(PSXINT_SPU_UPDATE, evqueue.spuUpdateInterval);
+}
+
+// SPU_handleIRQ() is a wrapper function around SPU_async(),
+// allowing handling as a generic event
+static void SPU_handleIRQ(void)
+{
+#ifdef spu_pcsxrearmed
+	// NOTE: Only spu_pcsxrearmed actually implements handling of SPU HW IRQs.
+	SPU_async(psxRegs.cycle, 0);
+#endif
+}
+
+// Returns true if event 'lh_ev' is more imminent than 'rh_ev'.
+static inline bool EventMoreImminent(u8 lh_ev, u8 rh_ev)
+{
+	// Compare the two event timestamps, interpreting the result as a signed
+	//  integer in case one or both cross psxRegs.cycle overflow boundary.
+	int lh_tmp = psxRegs.intCycle[lh_ev].sCycle + psxRegs.intCycle[lh_ev].cycle
+	             - psxRegs.cycle;
+	int rh_tmp = psxRegs.intCycle[rh_ev].sCycle + psxRegs.intCycle[rh_ev].cycle
+	             - psxRegs.cycle;
+	return lh_tmp < rh_tmp;
+}
+
+static inline void evqueueClear(void)
+{
+	evqueue.useEndIdx = evqueue.useBeginIdx = 0;
+}
+
+static inline size_t evqueueSize(void)
+{
+	return evqueue.useEndIdx - evqueue.useBeginIdx;
+}
+
+static inline bool evqueueEmpty(void)
+{
+	return evqueue.useEndIdx == evqueue.useBeginIdx;
+}
+
+static inline u8 evqueueFront(void)
+{
+	return evqueue.queue[evqueue.useBeginIdx];
+}
+
+// Returns pointer to first element in use
+static inline u8* evqueueFrontPtr(void)
+{
+	return evqueue.queue + evqueue.useBeginIdx;
+}
+
+// Returns pointer to one past the last element in use,
+//  but when empty, points to same element as evqueueFrontPtr()
+static inline u8* evqueueEndPtr(void)
+{
+	return evqueue.queue + evqueue.useEndIdx;
+}
+
+// Insert new element, keeping queue sorted by event imminency.
+//  Event's timestamp in psxRegs.intCycle[] must be set before call.
+//  Important: two elements equivalent in imminency keep their relative order,
+//  i.e., new events are inserted after existing equally-imminent events.
+static inline void evqueueAdd(u8 ev)
+{
+#ifdef DEBUG_EVENTS
+	if (evqueueSize() == EVQUEUE_CAPACITY) {
+		printf("ERROR: %s() could not find space in its array\n", __func__);
+		return;
 	}
 
-	schedule_persistent_events();
+	if (!evqueueConsistencyCheck()) {
+		printf("ERROR: Queue consistent ordering check failed in %s(),\n"
+	           "before adding event %u\n", __func__, ev);
+		evqueuePrintQueue();
+	}
+#endif
 
-	// Don't trust io_cycle_counter from a freeze (determines next call to
-	//  psxBranchTest() from interpreter/recompiler, which also handles
-	//  issuing HW IRQ exceptions which might have been pending at save.)
-	psxRegs.io_cycle_counter = 0;
+	u8 *it = evqueueFrontPtr();  // iterator
+
+	while ((it != evqueueEndPtr()) && !EventMoreImminent(ev, *it))
+		++it;
+
+	// Rather than be fancy and compute position relative to front/end, to
+	//  decide how to insert, we choose evqueueInsertFront() when possible,
+	//  to keep object code size small. Our queue is usually pretty small.
+	if (evqueue.useBeginIdx > 0) {
+		// Insert at position 'it-1', moving backward all elements between
+		//  that position and the front
+		evqueueInsertFront(it, ev);
+	} else {
+		// Insert at position 'it', moving forward all elements between that
+		//  position and the end
+		evqueueInsertBack(it, ev);
+	}
+
+#ifdef DEBUG_EVENTS
+	if (!evqueueConsistencyCheck()) {
+		printf("ERROR: Queue consistent ordering check failed in %s(),\n"
+	           "after adding event %u\n", __func__, ev);
+		evqueuePrintQueue();
+	}
+#endif
 }
 
-void EventQueue::event_stub_func()
+// Remove the first matching element, returning false if not found
+static bool evqueueRemove(u8 ev)
 {
+	u8 *it = evqueueFrontPtr();
+	while ((it != evqueueEndPtr()) && (*it != ev))
+		++it;
+
+	if (it == evqueueEndPtr())
+		return false;
+
+	// Rather than be fancy and compute position relative to front/end, we
+	//  always shrink array towards front, to keep object code size small.
+	--evqueue.useEndIdx;
+	evqueueMoveBackward(it + 1, evqueueEndPtr());
+
+#ifdef DEBUG_EVENTS
+	if (!evqueueConsistencyCheck()) {
+		printf("ERROR: Queue consistent ordering check failed in %s(),\n"
+	           "after removing event %u\n", __func__, ev);
+		evqueuePrintQueue();
+	}
+#endif
+
+	return true;
+}
+
+static inline void evqueueRemoveFront(void)
+{
+#ifdef DEBUG_EVENTS
+	if (evqueueEmpty()) {
+		printf("ERROR: %s() called when queue is empty\n", __func__);
+		return;
+	}
+#endif
+
+	++evqueue.useBeginIdx;
+}
+
+// Copy all elements between [start,end] to [start+1,end+1].
+//  If start address is greater than end, no copy will occur.
+static inline void evqueueMoveForward(u8 *start, u8 *end)
+{
+	for (u8 *ptr = end; ptr >= start; --ptr)
+		*(ptr+1) = *ptr;
+}
+
+// Copy all elements between [start,end] to [start-1,end-1].
+//  If start address is greater than end, no copy will occur.
+static inline void evqueueMoveBackward(u8 *start, u8 *end)
+{
+	for (u8 *ptr = start; ptr <= end; ++ptr)
+		*(ptr-1) = *ptr;
+}
+
+// Insert new entry 't' before position 'it'. Array contents before the
+//  position will be moved backward before insertion.
+static inline void evqueueInsertFront(u8 *it, u8 ev)
+{
+	--it;
+	evqueueMoveBackward(evqueueFrontPtr(), it);
+	--evqueue.useBeginIdx;
+	*it = ev;
+}
+
+// Insert new entry 't' at position 'it'. Array contents between that
+//  position and the end will be moved forwards before the insertion.
+static inline void evqueueInsertBack(u8 *it, u8 ev)
+{
+	evqueueMoveForward(it, evqueueEndPtr()-1);
+	++evqueue.useEndIdx;
+	*it = ev;
 }
 
 #ifdef DEBUG_EVENTS
-void EventQueue::print_event_queue()
+static bool evqueueConsistencyCheck(void)
 {
-	printf("Queue contains %u events:\n", queue.size());
-	for (uint8_t *ev = queue.front_ptr(); ev != queue.end_ptr(); ++ev) {
-		printf("EV: %u SCYCLE: %u CYCLE: %u\n", *ev, psxRegs.intCycle[*ev].sCycle, psxRegs.intCycle[*ev].cycle);
-	}
+	if (evqueueSize() < 2)
+		return true;
 
-	// Consistent ordering check:
-	for (uint8_t *ev = queue.front_ptr(); ev != queue.end_ptr(); ++ev) {
-		EventMoreImminent compare_func;
-		if (ev < (queue.end_ptr() - 1)) {
-			if (!compare_func(*ev, *(ev+1))) {
-				if ((psxRegs.intCycle[*ev].sCycle + psxRegs.intCycle[*ev].cycle) !=
-					(psxRegs.intCycle[*(ev+1)].sCycle + psxRegs.intCycle[*(ev+1)].cycle)) {
-					printf("ERROR: EV %u > EV %u\n", *ev, *(ev+1));
-				}
+	for (u8 *ev = evqueueFrontPtr(); ev < (evqueueEndPtr()-1); ++ev) {
+		if (!EventMoreImminent(*ev, *(ev+1))) {
+			if ((psxRegs.intCycle[*ev].sCycle + psxRegs.intCycle[*ev].cycle) !=
+			    (psxRegs.intCycle[*(ev+1)].sCycle + psxRegs.intCycle[*(ev+1)].cycle)) {
+				printf("ERROR: %s() failed: EV %u > EV %u\n", __func__, *ev, *(ev+1));
+				return false;
 			}
 		}
 	}
+	return true;
+}
+
+static void evqueuePrintQueue(void)
+{
+	printf("Queue contains %zu events, useBeginIdx: %u  useEndIdx: %u\n",
+			evqueueSize(), evqueue.useBeginIdx, evqueue.useEndIdx);
+	for (u8 *ev = evqueueFrontPtr(); ev != evqueueEndPtr(); ++ev) {
+		printf("EV: %u SCYCLE: %u CYCLE: %u\n",
+		       *ev, psxRegs.intCycle[*ev].sCycle, psxRegs.intCycle[*ev].cycle);
+	}
+
+	if (evqueueConsistencyCheck())
+		printf("Queue consistent ordering check passes.\n");
 }
 #endif
-
-EventQueue::EventFunc * const EventQueue::eventFuncs[PSXINT_COUNT] = {
-	[PSXINT_SIO]             = sioInterrupt,
-	[PSXINT_CDR]             = cdrInterrupt,
-	[PSXINT_CDREAD]          = cdrReadInterrupt,
-	[PSXINT_GPUDMA]          = gpuInterrupt,
-	[PSXINT_MDECOUTDMA]      = mdec1Interrupt,
-	[PSXINT_SPUDMA]          = spuInterrupt,
-	[PSXINT_GPUBUSY]         = EventQueue::event_stub_func, // UNIMPLEMENTED (TODO?)
-	[PSXINT_MDECINDMA]       = mdec0Interrupt,
-	[PSXINT_GPUOTCDMA]       = gpuotcInterrupt,
-	[PSXINT_CDRDMA]          = cdrDmaInterrupt,
-	[PSXINT_NEWDRC_CHECK]    = EventQueue::event_stub_func, // UNIMPLEMENTED (TODO?)
-	[PSXINT_RCNT]            = psxRcntUpdate,
-	[PSXINT_CDRLID]          = cdrLidSeekInterrupt,
-	[PSXINT_CDRPLAY]         = cdrPlayInterrupt,
-	[PSXINT_SPUIRQ]          = HandleSPU_IRQ,
-	[PSXINT_SPU_UPDATE]      = UpdateSPU,
-	[PSXINT_RESET_CYCLE_VAL] = psxResetCycleValue,
-	[PSXINT_SIO_SYNC_MCD]    = sioSyncMcds
-};
-
-EventQueue psxEventQueue;

--- a/src/psxevents.h
+++ b/src/psxevents.h
@@ -20,9 +20,6 @@
  *
  * Added July 2016 by senquack (Daniel Silsby)
  *
- * Class SortedArray is based largely on OpenMSX's SchedulerQueue class, found
- *  here: https://github.com/openMSX/openMSX/blob/master/src/SchedulerQueue.hh
- *  (Which was primarily written by Wouter Vermaelen a.k.a. m9710797)
  */
 
 #ifndef PSXEVENTS_H
@@ -32,7 +29,7 @@
 #include <stdint.h>
 #include "r3000a.h"
 
-enum psxEventType {
+enum psxEventNum {
 	PSXINT_SIO = 0,
 	PSXINT_CDR,
 	PSXINT_CDREAD,
@@ -43,7 +40,7 @@ enum psxEventType {
 	PSXINT_MDECINDMA,
 	PSXINT_GPUOTCDMA,
 	PSXINT_CDRDMA,
-	PSXINT_NEWDRC_CHECK,   //From PCSX Rearmed, but not implemented here (TODO?)
+	PSXINT_NEWDRC_CHECK,   //Used in PCSX Rearmed dynarec, but not implemented here (TODO?)
 	PSXINT_RCNT,
 	PSXINT_CDRLID,
 	PSXINT_CDRPLAY,
@@ -61,252 +58,13 @@ enum psxEventType {
 	                                 // psxRegs.intCycles[] for fast checking
 };
 
-// This is similar to a sorted vector<T>, though this container can have spare
-//  capacity both at the front and at the end (vector only at the end). This
-//  means that when you remove the 'smallest' element and insert a new element
-//  that's only slightly 'bigger' than the smallest one, there's a very good
-//  chance this insert runs in O(1) (for vector it's O(N), with N the size of
-//  the vector). This is a scenario that occurs very often in the scheduler
-//  code.
-template<typename T, typename T_IDX_TYPE, size_t T_CAPACITY, size_t T_SPARE_FRONT>
-class SortedArray {
-public:
-	SortedArray() { clear(); }
+void psxEvqueueInit(void);
+void psxEvqueueInitFromFreeze(void);
+void psxEvqueueAdd(psxEventNum ev, u32 cycles_after);
+void psxEvqueueRemove(psxEventNum ev);
+void psxEvqueueDispatchAndRemoveFront(psxRegisters *pr);
 
-	void clear()
-	{
-		useBeginIdx = T_SPARE_FRONT;
-		useEndIdx = useBeginIdx;
-	}
-
-	size_t capacity() const { return T_CAPACITY; }
-	size_t spare_front() const { return useBeginIdx; }
-	size_t spare_back() const { return T_CAPACITY - useEndIdx; }
-	size_t size() const { return useEndIdx - useBeginIdx; }
-	bool empty() const { return useEndIdx == useBeginIdx; }
-
-	// Returns reference to the first element in use
-	T& front() { return storage[useBeginIdx]; }
-	const T& front() const { return storage[useBeginIdx]; }
-
-	// Returns pointer to the first element in use
-	T* front_ptr() { return storage + useBeginIdx; }
-	const T* front_ptr() const { return storage + useBeginIdx; }
-
-	// Returns pointer to one past the last element in use,
-	//  but when empty, points to same element as front_ptr()
-	T* end_ptr() { return storage + useEndIdx; }
-	const T* end_ptr() const { return storage + useEndIdx; }
-
-	bool contains(const T& t) const
-	{
-		const T *it = front_ptr();
-		while ((it != end_ptr()) && (*it != t))
-			++it;
-		return it != end_ptr();
-	}
-
-	// Insert new element.
-	//  Elements are sorted according to the given predicate. Predicate
-	//  will return 'true' for sort_pred(ELEMENT_BEFORE, ELEMENT_AFTER).
-	//  Important: two elements that are equivalent according to predicate
-	//  keep their relative order, i.e., newly-inserted elements are inserted
-	//  after existing equivalent elements.
-	template<typename T_SORT_PREDICATE>
-	void insert(const T& t, T_SORT_PREDICATE sort_pred)
-	{
-		T* it = front_ptr();
-
-		while ((it != end_ptr()) && !sort_pred(t, *it))
-			++it;
-
-		// Determine if insertion point is closer to beginning of used space,
-		//  so the minimum amount of data must be rearranged
-		if ((it - front_ptr()) <= (end_ptr() - it)) {
-			// Closer to beginning, so moving preceding elements backwards is best
-			if (useBeginIdx != 0) {
-				// Insert at position 'it-1', moving backward all elements between
-				//  that position and the front
-				insert_front(it, t);
-			} else if (useEndIdx != T_CAPACITY) {
-				// Insert at position 'it', moving forward all elements between that
-				//  position and the end
-				insert_back(it, t);
-			} else {
-#ifdef DEBUG_EVENTS
-				printf("ERROR: SortedArray::insert() could not find space in its array (1)\n");
-#endif
-			}
-		} else {
-			// Closer to end, so moving succeeding elements forwards is best
-			if (useEndIdx != T_CAPACITY) {
-				// Insert at position 'it', moving forward all elements between that
-				//  position and the end
-				insert_back(it, t);
-			} else if (useBeginIdx != 0) {
-				// Insert at position 'it-1', moving backward all elements between
-				//  that position and the front
-				insert_front(it, t);
-			} else {
-#ifdef DEBUG_EVENTS
-				printf("ERROR: SortedArray::insert() could not find space in its array (2)\n");
-#endif
-			}
-		}
-	}
-
-	// Remove the head of the sorted array
-	void remove_front()
-	{
-		assert(!empty());
-		++useBeginIdx;
-	}
-
-	// Remove the first matching element, returning false if not found
-	bool remove(const T& t)
-	{
-		T *it = front_ptr();
-		while ((it != end_ptr()) && (*it != t))
-			++it;
-
-		if (it == end_ptr())
-			return false;
-
-		if ((it - front_ptr()) < (end_ptr() - it - 1)) {
-			// Element is closer to the beginning of the array
-			move_forward(front_ptr(), it - 1);
-			++useBeginIdx;
-		} else {
-			// Element is closer to the end of the array
-			--useEndIdx;
-			move_backward(it + 1, end_ptr());
-		}
-		return true;
-	}
-
-private:
-	// Copy all elements between [start,end] to [start+1,end+1].
-	//  If start address is greater than end, no copy will occur.
-	void move_forward(T* const start, T* const end)
-	{
-		for (T* ptr = end; ptr >= start; --ptr)
-			*(ptr + 1) = *ptr;
-	}
-
-	// Copy all elements between [start,end] to [start-1,end-1].
-	//  If start address is greater than end, no copy will occur.
-	void move_backward(T* const start, T* const end)
-	{
-		for (T* ptr = start; ptr <= end; ++ptr)
-			*(ptr - 1) = *ptr;
-	}
-
-	// Insert new entry 't' before position 'it'. Array contents before the
-	//  position will be moved backward before insertion.
-	void insert_front(T* it, const T& t)
-	{
-		--it;
-		move_backward(front_ptr(), it);
-		--useBeginIdx;
-		*it = t;
-	}
-
-	// Insert new entry 't' at position 'it'. Array contents between that
-	//  position and the end will be moved forwards before the insertion.
-	void insert_back(T* it, const T& t)
-	{
-		move_forward(it, end_ptr() - 1);
-		++useEndIdx;
-		*it = t;
-	}
-
-private:
-	T_IDX_TYPE useBeginIdx;    // Index of first used element of storage[] 
-	T_IDX_TYPE useEndIdx;      // One past last used index of storage[], or same
-	                           //  value as useBeginIdx when queue is empty.
-	T storage[T_CAPACITY];
-};
-
-class EventQueue {
-public:
-	// Schedule an event to occur after 'cycles_after' have passed from now.
-	//  If it's already enqueued, it will be rescheduled, without
-	//  calling its handler function.
-	void enqueue(const psxEventType ev, const uint32_t cycles_after);
-
-	// Unschedule an event, without calling its handler function.
-	void dequeue(const psxEventType ev);
-
-	// Remove the front of the queue and call its handler function:
-	void dispatch_and_remove_front();
-
-	uint8_t front() const { return queue.front(); }
-	bool    empty() const { return queue.empty(); }
-	size_t  size()  const { return queue.size(); }
-	void    clear_internal_queue() { return queue.clear(); }
-
-	bool contains(const psxEventType ev) const
-	{
-		// If an event is present in the queue, it must also be set in
-		//  psxRegs.interrupt, and is faster to just check that:
-		return psxRegs.interrupt & ((uint32_t)1 << ev);
-	}
-
-	// Certain events should always be scheduled when either starting
-	//  the emulator for the first time, restarting a game, or
-	//  loading a save-state. By ensuring these events are always loaded
-	//  on save-state load, compatibility with savestates from before
-	//  event-system overhaul is ensured.
-	void schedule_persistent_events();
-
-	// Build the event queue afresh from psxRegs.interrupt and psxRegs.intCycle[]
-	void init_from_freeze();
-
-	// At very intermittent intervals, psxRegs.cycle is reset to 0 to prevent
-	//  it from ever overflowing (simplifies checks against it elsewhere).
-	//  This function fixes up timestamps of all queued events when this occurs.
-	void adjust_event_timestamps(const uint32_t prev_cycle_val)
-	{
-		for (uint8_t *ev = queue.front_ptr(); ev != queue.end_ptr(); ++ev) {
-			psxRegs.intCycle[*ev].sCycle -= prev_cycle_val;
-		}
-
-		psxRegs.intCycle[PSXINT_NEXT_EVENT].sCycle -= prev_cycle_val;
-	}
-
-	// Functor specifying sort criteria to SortedArray member class
-	struct EventMoreImminent {
-		inline bool operator()(const uint8_t &lh, const uint8_t &rh) const
-		{
-			// Compare the two event timestamps, interpreting the result as a signed
-			//  integer in case one or both cross psxRegs.cycle overflow boundary.
-			int lh_tmp = psxRegs.intCycle[lh].sCycle + psxRegs.intCycle[lh].cycle - psxRegs.cycle;
-			int rh_tmp = psxRegs.intCycle[rh].sCycle + psxRegs.intCycle[rh].cycle - psxRegs.cycle;
-			return lh_tmp < rh_tmp;
-		}
-	};
-
-#ifdef DEBUG_EVENTS
-	void print_event_queue();
-#endif
-
-private:
-	SortedArray<uint8_t, uint8_t, PSXINT_COUNT, 2> queue;
-
-	// If a PSXINT_* event number is not implemented, call this stub
-	//  (should never happen)
-	static void event_stub_func();
-
-	// Event handler function table:
-	typedef void (EventFunc)();
-	static EventFunc * const eventFuncs[PSXINT_COUNT];
-};
-
-extern EventQueue psxEventQueue;
-
-/* psxBranchTest() debug statistics */
-#ifdef DEBUG_EVENTS
-extern unsigned int bt_necessary, bt_unnecessary;
-#endif
+// Should be called when Config.PsxType changes
+void SPU_resetUpdateInterval(void);
 
 #endif //PSXEVENTS_H

--- a/src/r3000a.cpp
+++ b/src/r3000a.cpp
@@ -82,10 +82,7 @@ void psxReset() {
 	psxRegs.CP0.r[12] = 0x10900000; // COP0 enabled | BEV = 1 | TS = 1
 	psxRegs.CP0.r[15] = 0x00000002; // PRevID = Revision ID, same as R3000A
 
-	// Queue up any events that always get scheduled (e.g., SPU update)
-	psxEventQueue.clear_internal_queue();
-	psxEventQueue.schedule_persistent_events();
-
+	psxEvqueueInit();  // Event scheduler queue
 	psxHwReset();
 	psxBiosInit();
 
@@ -143,7 +140,7 @@ void psxBranchTest()
 			psxRegs.intCycle[PSXINT_NEXT_EVENT].cycle) {
 		// After dispatching the most-imminent event, this will update
 		//  the intCycle[PSXINT_NEXT_EVENT] element.
-		psxEventQueue.dispatch_and_remove_front();
+		psxEvqueueDispatchAndRemoveFront(&psxRegs);
 	}
 
 	psxRegs.io_cycle_counter = psxRegs.intCycle[PSXINT_NEXT_EVENT].sCycle +

--- a/src/r3000a.h
+++ b/src/r3000a.h
@@ -166,6 +166,7 @@ typedef struct {
 	s8 *psxR;
 	s8 *psxH;
 
+	void *reserved;
 	int writeok;
 } psxRegisters;
 

--- a/src/sio.cpp
+++ b/src/sio.cpp
@@ -97,7 +97,7 @@ void sioInit(void) {
 //           TODO: Add support for newer PCSXR Config.Sio option
 // clk cycle byte
 static inline void SIO_INT(void) {
-	psxEventQueue.enqueue(PSXINT_SIO, psxSio.sio_cycle);
+	psxEvqueueAdd(PSXINT_SIO, psxSio.sio_cycle);
 }
 
 void sioWrite8(unsigned char value) {
@@ -292,7 +292,7 @@ void sioWriteCtrl16(unsigned short value) {
 	if ((psxSio.CtrlReg & SIO_RESET) || !(psxSio.CtrlReg & DTR)) {
 		psxSio.padst = 0; psxSio.mcdst = 0; psxSio.parp = 0;
 		psxSio.StatReg = TX_RDY | TX_EMPTY;
-		psxEventQueue.dequeue(PSXINT_SIO);
+		psxEvqueueRemove(PSXINT_SIO);
 	}
 }
 
@@ -481,7 +481,7 @@ int sioMcdWrite(enum MemcardNum mcd_num, const char *src, uint32_t adr, int size
 	// If memcard file was already open for writing, or was just opened by
 	//  call to SaveMcd(), (re)schedule a memcard file flush/sync/close
 	if (memcards[mcd_num].file != NULL)
-		psxEventQueue.enqueue(PSXINT_SIO_SYNC_MCD, MEMCARD_SYNC_DELAY);
+		psxEvqueueAdd(PSXINT_SIO_SYNC_MCD, MEMCARD_SYNC_DELAY);
 
 	return retval;
 }

--- a/src/spu/spu_pcsxrearmed/spu.c
+++ b/src/spu/spu_pcsxrearmed/spu.c
@@ -1271,21 +1271,6 @@ void CALLBACK SPUasync(unsigned int cycle, unsigned int flags)
  }
 }
 
-// SPU UPDATE... new epsxe func
-//  1 time every 32 hsync lines
-//  (312/32)x50 in pal
-//  (262/32)x60 in ntsc
-
-// since epsxe 1.5.2 (linux) uses SPUupdate, not SPUasync, I will
-// leave that func in the linux port, until epsxe linux is using
-// the async function as well
-
-//senquack - disabled this, it just is confusing having both spuUpdate() and also a dummy
-//           SPUupdate() function just for some sort of epsxe compatibility:
-//void CALLBACK SPUupdate(void)
-//{
-//}
-
 // XA AUDIO
 
 void CALLBACK SPUplayADPCMchannel(xa_decode_t *xap)


### PR DESCRIPTION
* Rewrote psxevents.cpp event queue in straight C, simplified
  insertion/removal algorithm.

* Bring back 'reserved' psxRegisters struct var, to preserve old
  savestate compatibility. Who knows, it might serve useful someday.

* Incremented savestate version number, old version number
  indicates it is a buggy old savestate that had always unknowingly
  skipped writing data past SPU data.

* When old savestate is encountered, hacks will attempt to preserve
  compatibility (as best as the buggy saves ever did work anway).

* Improve savestate save/load method, eliminate infinitely-growing
  callstack in psxcounters.cpp from hacky old methods used.

* Add savestate error reporting in frontend.
  TODO; improve save/load interface, add screenshots