### PR TITLE
Mirroring + dynarec fix

### DIFF
--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -25,7 +25,7 @@ MCD1_FILE = \"mcd001.mcr\"
 MCD2_FILE = \"mcd002.mcr\"
 
 ifdef A320
-	C_ARCH = -mips32 -msoft-float
+	C_ARCH = -mips32 -msoft-float -DTMPFS_MIRRORING -DTMPFS_DIR=\"/tmp\"
 else
 	C_ARCH = -mips32r2 -DSHMEM_MIRRORING
 endif

--- a/src/psxmem.h
+++ b/src/psxmem.h
@@ -46,6 +46,12 @@
 
 #endif
 
+/* This is used for direct writes in mips recompiler */
+#if defined(PSXREC) && \
+	(defined(SHMEM_MIRRORING) || defined(TMPFS_MIRRORING))
+extern bool psxM_mirrored;
+#endif
+
 extern s8 *psxM;
 #define psxMs8(mem)		psxM[(mem) & 0x1fffff]
 #define psxMs16(mem)	(SWAP16(*(s16*)&psxM[(mem) & 0x1fffff]))

--- a/src/recompiler/mips/rec_lsu.cpp.h
+++ b/src/recompiler/mips/rec_lsu.cpp.h
@@ -5,8 +5,8 @@
 // Upper/lower 64K of PSX RAM (psxM[]) is now mirrored to virtual address
 //  regions surrounding psxM[]. This allows skipping mirror-region boundary
 //  check which special-cased loads/stores that crossed the boundary, the
-//  Einhander game fix. See notes in psxmem.cpp psxMemInit().
-#ifdef SHMEM_MIRRORING
+//  Einhander game fix. See notes in psxmem.cpp.
+#if defined(SHMEM_MIRRORING) || defined(TMPFS_MIRRORING)
 #define SKIP_SAME_2MB_REGION_CHECK
 #endif
 


### PR DESCRIPTION
Add support for tmpfs virtual mmap() RAM mirroring, allows Dingoo A320
MIPS32R1 platform to use it.

Fix/improvement to calc_wl_wr() LWL/LWR/SWL/SWR opcode
series count function.