### PR TITLE
gpu_unai: Temporary fix for dither quality

### DIFF
--- a/src/gpu/gpu_unai/gpu_inner_quantization.h
+++ b/src/gpu/gpu_unai/gpu_inner_quantization.h
@@ -54,6 +54,15 @@ static void SetupDitheringConstants()
 
 			u32 component = ((DitherMatrix[offset] + 1) << 4) / 65; //[5.5] -> [5]
 
+			// XXX - senquack - hack Dec 2016
+			//  Until JohnnyF gets the time to work further on dithering,
+			//   force lower bit of component to 0. This fixes grid pattern
+			//   affecting quality of dithered image, as well as loss of
+			//   detail in dark areas. With lower bit unset like this, existing
+			//   27-bit accuracy of dithering math is unneeded, could be 24-bit.
+			//   Is 8x8 matrix overkill as a result, can we use 4x4?
+			component &= ~1;
+
 			gpu_unai.DitherMatrix[offset] = (component)
 			                              | (component << 10)
 			                              | (component << 20);


### PR DESCRIPTION
For now, force lower bit of dither table component vals to
0, to fix persistent grid pattern as well as loss of detail
in dark areas.

TODO: remove hack when JohnnyF gets time to work on dithering.