### PR TITLE
Plugin_lib, SPU work

### DIFF
--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -35,6 +35,7 @@ CFLAGS = $(C_ARCH) -mplt -mno-shared -ggdb3 -O2 -DGCW_ZERO \
 	-Wno-sign-compare -Wno-cast-align \
 	-Isrc -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) \
 	-Isrc/port/$(PORT) \
+	-Isrc/plugin_lib \
 	-DXA_HACK \
 	-DINLINE="static __inline__" -Dasm="__asm__ __volatile__" \
 	$(SDL_CFLAGS)
@@ -59,6 +60,7 @@ all: maketree $(TARGET)
 OBJS = \
 	obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o \
 	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/psxevents.o \
+	obj/psxcommon.o obj/plugin_lib/plugin_lib.o \
 	obj/psxinterpreter.o \
 	obj/mdec.o obj/decode_xa.o \
 	obj/cdriso.o obj/cdrom.o obj/ppf.o \

--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -99,6 +99,32 @@ OBJS += obj/plugin_lib/perfmon.o
 #******************************************
 # spu_pcsxrearmed section BEGIN
 #******************************************
+
+##########
+# Use a non-default SPU update frequency for these slower devices
+#  to avoid audio dropouts. 0: once-per-frame (default)   5: 32-times-per-frame
+#
+#  On slower Dingoo A320, update 8 times per frame
+ifdef A320
+CFLAGS += -DSPU_UPDATE_FREQ_DEFAULT=3
+else
+#  On faster GCW Zero platform, update 4 times per frame
+CFLAGS += -DSPU_UPDATE_FREQ_DEFAULT=2
+endif
+##########
+
+##########
+# Similarly, set higher XA audio update frequency for slower devices
+#
+#  On slower Dingoo A320, force XA to update 8 times per frame (val 4)
+ifdef A320
+CFLAGS += -DFORCED_XA_UPDATES_DEFAULT=4
+else
+#  On faster GCW Zero platform, use auto-update
+CFLAGS += -DFORCED_XA_UPDATES_DEFAULT=1
+endif
+##########
+
 ifeq ($(SPU),spu_pcsxrearmed)
 # Specify which audio backend to use:
 SOUND_DRIVERS=sdl

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -24,6 +24,7 @@ CFLAGS = -ggdb3 -O2 -march=native -DGCW_ZERO \
 	-Wno-sign-compare -Wno-cast-align \
 	-Isrc -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) \
 	-Isrc/port/$(PORT) \
+	-Isrc/plugin_lib \
 	-DXA_HACK \
 	-DINLINE="static __inline__" -Dasm="__asm__ __volatile__" \
 	$(SDL_CFLAGS)
@@ -44,6 +45,7 @@ all: maketree $(TARGET)
 OBJS = \
 	obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o \
 	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/psxevents.o \
+	obj/psxcommon.o obj/plugin_lib/plugin_lib.o \
 	obj/psxinterpreter.o \
 	obj/mdec.o obj/decode_xa.o \
 	obj/cdriso.o obj/cdrom.o obj/ppf.o \

--- a/Makefile.win32
+++ b/Makefile.win32
@@ -27,6 +27,7 @@ CFLAGS = -ggdb3 -O2 -march=native -DGCW_ZERO \
 	-Wno-format -Wno-format-extra-args \
 	-Isrc -Isrc/spu/$(SPU) -D$(SPU) -Isrc/gpu/$(GPU) \
 	-Isrc/port/$(PORT) \
+	-Isrc/plugin_lib \
 	-DXA_HACK \
 	-DINLINE="static __inline__" -Dasm="__asm__ __volatile__" \
 	$(SDL_CFLAGS)
@@ -51,6 +52,7 @@ all: maketree $(TARGET)
 OBJS = \
 	obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o \
 	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/psxevents.o \
+	obj/psxcommon.o obj/plugin_lib/plugin_lib.o \
 	obj/psxinterpreter.o \
 	obj/mdec.o obj/decode_xa.o \
 	obj/cdriso.o obj/cdrom.o obj/ppf.o \

--- a/src/gpu/gpu_dfxvideo/gpu_fps.h
+++ b/src/gpu/gpu_dfxvideo/gpu_fps.h
@@ -39,6 +39,8 @@ static unsigned long timeGetTime(void)
  return tv.tv_sec * 100000 + tv.tv_usec/10;            // to do that, but at least it works
 }
 
+// Dec 2016: Frame limiting now handled by plugin_lib
+#if 0
 static void FrameCap (void)
 {
  static unsigned long curticks, lastticks, _ticks_since_last_update;
@@ -83,6 +85,10 @@ static void FrameCap (void)
       }
     }
   }
+}
+#endif //0
+static void FrameCap (void)
+{
 }
 
 static void calcfps(void)
@@ -268,6 +274,8 @@ static void FrameSkip(void)
 }
 
 
+// Dec 2016: Frame limiting now handled by plugin_lib
+#if 0
 static void PCFrameCap (void)
 {
  static unsigned long curticks, lastticks, _ticks_since_last_update;
@@ -286,6 +294,10 @@ static void PCFrameCap (void)
      TicksToWait = (TIMEBASE/ (unsigned long)fFrameRateHz);
     }
   }
+}
+#endif //0
+static void PCFrameCap (void)
+{
 }
 
 static void PCcalcfps(void)

--- a/src/gpu/gpu_unai/gpu.cpp
+++ b/src/gpu/gpu_unai/gpu.cpp
@@ -802,21 +802,6 @@ static void GPU_frameskip (bool show)
 			case 5: if (spd<90) gpu_unai.frameskip.skipFrame=true; else gpu_unai.frameskip.skipFrame=false; break; // frameskip on (spd<90%)
 		}
 	}
-
-	// Limit FPS
-	if (Config.FrameLimit)
-	{
-		static u32 next=now; // next frame
-#ifdef GCW_ZERO
-		if (show) {
-			while (now < next)
-				now = get_ticks(); // busy loop
-		}
-#else
-		if (show) { if (now<next) wait_ticks(next-now); }
-#endif
-		next+=(IS_PAL?(TPS/50):((u32)(((double)TPS)/59.94)));
-	}
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/gpu/gpulib/gpu.h
+++ b/src/gpu/gpulib/gpu.h
@@ -87,7 +87,6 @@ struct psx_gpu {
     uint32_t active:1;
     uint32_t allow:1;
     uint32_t frame_ready:1;
-    const int *advice;
     uint32_t last_flip_frame;
     uint32_t pending_fill[3];
   } frameskip;
@@ -108,13 +107,6 @@ struct gpulib_config_t {
 	void *(*mmap)(unsigned int size);
 	void  (*munmap)(void *ptr, unsigned int size);
 #endif
-	// some stats, for display by some plugins
-	int flips_per_sec, cpu_usage;
-	float vsps_cur; // currect vsync/s
-	// gpu options
-	int   frameskip;
-	int   fskip_advice;
-	unsigned int flip_cnt;
 
 	struct {
 		int   iUseDither;
@@ -134,6 +126,7 @@ struct gpulib_config_t {
 
 extern gpulib_config_t gpulib_config;
 
+void gpulib_frameskip_prepare(void);
 void gpulib_set_config(const gpulib_config_t *config);
 
 int  renderer_init(void);

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -29,6 +29,7 @@
 #include "cdrom.h"
 #include "mdec.h"
 #include "gpu.h"
+#include "plugin_lib.h"
 #include "ppf.h"
 #include "psxevents.h"
 #include <fcntl.h>
@@ -881,7 +882,7 @@ int LoadState(const char *file) {
 skip_missing_data_hack:
 
 	SaveFuncs.close(f);
-
+	pl_reset();  // Reset plugin_lib
 	return 0;
 
 error:

--- a/src/plugin_lib/plugin_lib.cpp
+++ b/src/plugin_lib/plugin_lib.cpp
@@ -1,0 +1,144 @@
+/***************************************************************************
+ * (C) notaz, 2010-2011                                                    *
+ * (C) senquack, PCSX4ALL team 2016                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02111-1307 USA.           *
+ ***************************************************************************/
+
+#include <sys/time.h>
+#include <unistd.h>
+
+#include "plugin_lib.h"
+#include "perfmon.h"
+#include "plugins.h"
+#include "psxcommon.h"
+
+#ifdef USE_GPULIB
+#include "gpu/gpulib/gpu.h"
+#endif
+
+// Used by GPU plugins to decide when to frameskip
+int pl_fskip_advice;
+
+static struct {
+	int frameskip;
+	int is_pal, frame_interval, frame_interval1024;
+	int vsync_usec_time;
+	struct timeval tv_expect;
+} pl_data;
+
+#define MAX_LAG_FRAMES 3
+
+#define tvdiff(tv, tv_old) \
+	((tv.tv_sec - tv_old.tv_sec) * 1000000 + tv.tv_usec - tv_old.tv_usec)
+
+void pl_frameskip_prepare(void)
+{
+	pl_fskip_advice = 0;
+
+	pl_data.frameskip = Config.FrameSkip;
+	pl_data.is_pal = (Config.PsxType == PSXTYPE_PAL);
+	pl_data.frame_interval = pl_data.is_pal ? 20000 : 16667;
+	pl_data.frame_interval1024 = pl_data.is_pal ? 20000*1024 : 17066667;
+
+	struct timeval now;
+	gettimeofday(&now, 0);
+	pl_data.vsync_usec_time = now.tv_usec;
+	while (pl_data.vsync_usec_time >= pl_data.frame_interval)
+		pl_data.vsync_usec_time -= pl_data.frame_interval;
+
+#ifdef USE_GPULIB
+	gpulib_frameskip_prepare();
+#endif
+}
+
+/* called on every vsync */
+void pl_frame_limit(void)
+{
+	struct timeval now;
+	int diff, usadj;
+
+	gettimeofday(&now, 0);
+
+	// Update performance monitor
+	pmonUpdate();
+
+	// If cfg settings change, catch it here
+	if (pl_data.frameskip != Config.FrameSkip ||
+	    pl_data.is_pal != (Config.PsxType == PSXTYPE_PAL))
+	{
+		pl_frameskip_prepare();
+	}
+
+	// tv_expect uses usec*1024 units instead of usecs for better accuracy
+	pl_data.tv_expect.tv_usec += pl_data.frame_interval1024;
+	if (pl_data.tv_expect.tv_usec >= (1000000 << 10)) {
+		pl_data.tv_expect.tv_usec -= (1000000 << 10);
+		pl_data.tv_expect.tv_sec++;
+	}
+	diff = (pl_data.tv_expect.tv_sec - now.tv_sec) * 1000000 +
+	       (pl_data.tv_expect.tv_usec >> 10) - now.tv_usec;
+
+	if (diff > MAX_LAG_FRAMES * pl_data.frame_interval ||
+	    diff < -MAX_LAG_FRAMES * pl_data.frame_interval)
+	{
+		//printf("pl_frame_limit reset, diff=%d, iv %d\n", diff, frame_interval);
+		pl_data.tv_expect = now;
+		diff = 0;
+		// try to align with vsync
+		usadj = pl_data.vsync_usec_time;
+		while (usadj < pl_data.tv_expect.tv_usec - pl_data.frame_interval)
+			usadj += pl_data.frame_interval;
+		pl_data.tv_expect.tv_usec = usadj << 10;
+	}
+
+	if (Config.FrameLimit && (diff > pl_data.frame_interval)) {
+		usleep(diff - pl_data.frame_interval);
+	}
+
+	if (Config.FrameSkip) {
+		if (diff < -pl_data.frame_interval) {
+			pl_fskip_advice = 1;
+		} else if (diff >= 0) {
+			pl_fskip_advice = 0;
+		}
+	}
+}
+
+void pl_init(void)
+{
+	pl_frameskip_prepare();
+
+	pmonReset(); // Reset performance monitor (FPS,CPU usage,etc)
+
+#ifdef USE_GPULIB
+	gpulib_set_config(&gpulib_config);
+#endif
+}
+
+// Called when emu paused and frontend is active
+void pl_pause(void)
+{
+	pmonPause();
+}
+
+// Called when leaving frontend back to emu
+void pl_resume(void)
+{
+	pmonResume();
+	pl_frameskip_prepare();
+	GPU_requestScreenRedraw(); // GPU plugin should redraw screen
+}

--- a/src/plugin_lib/plugin_lib.h
+++ b/src/plugin_lib/plugin_lib.h
@@ -1,0 +1,37 @@
+/***************************************************************************
+ * (C) notaz, 2010-2011                                                    *
+ * (C) senquack, PCSX4ALL team 2016                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02111-1307 USA.           *
+ ***************************************************************************/
+
+#ifndef PLUGIN_LIB_H
+#define PLUGIN_LIB_H
+
+extern int pl_fskip_advice;
+
+void pl_frameskip_prepare(void);
+void pl_frame_limit(void);
+void pl_init(void);
+void pl_pause(void);
+void pl_resume(void);
+
+static inline int pl_frameskip_advice(void)
+{
+	return pl_fskip_advice;
+}
+
+#endif // PLUGIN_LIB_H

--- a/src/plugin_lib/plugin_lib.h
+++ b/src/plugin_lib/plugin_lib.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  * (C) notaz, 2010-2011                                                    *
- * (C) senquack, PCSX4ALL team 2016                                        *
+ * (C) PCSX4ALL team 2016                                                  *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,20 +18,38 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02111-1307 USA.           *
  ***************************************************************************/
 
+/*
+ * Plugin library to assist with frameskip, controls, etc.
+ * Largely taken/based on Notaz's PCSX Rearmed.
+ *
+ * Added Dec 2016 by senquack (Daniel Silsby)
+ *
+ */
+
 #ifndef PLUGIN_LIB_H
 #define PLUGIN_LIB_H
 
-extern int pl_fskip_advice;
+#include <sys/time.h>
+
+struct pl_data_t {
+	int frameskip, fskip_advice;
+	int is_pal, frame_interval, frame_interval1024;
+	int vsync_usec_time;
+	struct timeval tv_expect;
+};
+
+extern struct pl_data_t pl_data;
 
 void pl_frameskip_prepare(void);
 void pl_frame_limit(void);
 void pl_init(void);
+void pl_reset(void);
 void pl_pause(void);
 void pl_resume(void);
 
 static inline int pl_frameskip_advice(void)
 {
-	return pl_fskip_advice;
+	return pl_data.fskip_advice;
 }
 
 #endif // PLUGIN_LIB_H

--- a/src/plugin_lib/plugin_lib.h
+++ b/src/plugin_lib/plugin_lib.h
@@ -30,11 +30,14 @@
 #define PLUGIN_LIB_H
 
 #include <sys/time.h>
+#include <stdint.h>
 
 struct pl_data_t {
-	int frameskip, fskip_advice;
-	int is_pal, frame_interval, frame_interval1024;
+	bool fskip_advice, dynarec_compiled, is_pal;
+	int8_t frameskip;
+	int frame_interval, frame_interval1024;
 	int vsync_usec_time;
+	unsigned int dynarec_active_vsyncs;
 	struct timeval tv_expect;
 };
 
@@ -47,9 +50,15 @@ void pl_reset(void);
 void pl_pause(void);
 void pl_resume(void);
 
-static inline int pl_frameskip_advice(void)
+static inline bool pl_frameskip_advice(void)
 {
 	return pl_data.fskip_advice;
+}
+
+// Dynamic recompilers call this to advise recompilation occurred
+static inline void pl_dynarec_notify(void)
+{
+	pl_data.dynarec_compiled = true;
 }
 
 #endif // PLUGIN_LIB_H

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -24,6 +24,7 @@
 
 #include "plugins.h"
 #include "psxevents.h"
+#include "plugin_lib.h"
 
 #ifdef SPU_PCSXREARMED
 #include "spu/spu_pcsxrearmed/spu_config.h"
@@ -83,6 +84,14 @@ void CALLBACK Trigger_SPU_IRQ(void) {
 // (This is used by games that use the actual hardware SPU IRQ like
 //  Need for Speed 3, Metal Gear Solid, Chrono Cross, etc.)
 void CALLBACK Schedule_SPU_IRQ(unsigned int cycles_after) {
+	if (Config.SpuUpdateFreq > 0 &&
+	    Config.SpuUpdateFreq <= SPU_UPDATE_FREQ_MAX)
+		cycles_after >>= Config.SpuUpdateFreq;
+
+	// If frameskip is advised, do SPU IRQ more frequently to avoid dropouts
+	if (pl_frameskip_advice())
+		cycles_after >>= 1;
+
 	psxEvqueueAdd(PSXINT_SPUIRQ, cycles_after);
 }
 

--- a/src/port/sdl/frontend.cpp
+++ b/src/port/sdl/frontend.cpp
@@ -798,7 +798,7 @@ static MENUITEM gui_SettingsItems[] = {
 	{(char *)"Emulation core       ", NULL, &emu_alter, &emu_show},
 	{(char *)"Cycle multiplier     ", NULL, &cycle_alter, &cycle_show},
 #endif
-	{(char *)"HLE                  ", NULL, &bios_alter, &bios_show},
+	{(char *)"HLE emulated BIOS    ", NULL, &bios_alter, &bios_show},
 	{(char *)"Set BIOS file        ", &bios_set, NULL, NULL},
 	{(char *)"RCntFix              ", NULL, &RCntFix_alter, &RCntFix_show},
 	{(char *)"VSyncWA              ", NULL, &VSyncWA_alter, &VSyncWA_show},
@@ -1037,7 +1037,7 @@ static MENUITEM gui_GPUSettingsItems[] = {
 	/* Not working with gpulib yet */
 	{(char *)"Show FPS             ", NULL, &fps_alter, &fps_show},
 #endif
-	{(char *)"Frame limit          ", NULL, &framelimit_alter, &framelimit_show},
+	{(char *)"Frame limiter        ", NULL, &framelimit_alter, &framelimit_show},
 #ifdef USE_GPULIB
 	/* Only working with gpulib */
 	{(char *)"Frame skip           ", NULL, &frameskip_alter, &frameskip_show},

--- a/src/port/sdl/frontend.cpp
+++ b/src/port/sdl/frontend.cpp
@@ -1195,6 +1195,45 @@ static char *interpolation_show()
 	}
 	return buf;
 }
+
+static int reverb_alter(u32 keys)
+{
+	if (keys & KEY_RIGHT) {
+		if (spu_config.iUseReverb < 1) spu_config.iUseReverb = 1;
+	} else if (keys & KEY_LEFT) {
+		if (spu_config.iUseReverb > 0) spu_config.iUseReverb = 0;
+	}
+
+	return 0;
+}
+
+static char *reverb_show()
+{
+	int val = spu_config.iUseReverb ? 1 : 0;
+	const char* str[] = { "off", "on" };
+	return (char*)str[val];
+}
+
+static int volume_alter(u32 keys)
+{
+	// Convert volume range 0..1024 to 0..16
+	int val = spu_config.iVolume / 64;
+	if (keys & KEY_RIGHT) {
+		if (val < 16) val++;
+	} else if (keys & KEY_LEFT) {
+		if (val > 0) val--;
+	}
+	spu_config.iVolume = val * 64;
+	return 0;
+}
+
+static char *volume_show()
+{
+	int val = spu_config.iVolume / 64;
+	static char buf[16] = "\0";
+	sprintf(buf, "%d", val);
+	return buf;
+}
 #endif //SPU_PCSXREARMED
 
 static int spu_settings_defaults()
@@ -1208,6 +1247,8 @@ static int spu_settings_defaults()
 	Config.SpuIrq = 0;
 #ifdef SPU_PCSXREARMED
 	spu_config.iUseInterpolation = 0;
+	spu_config.iUseReverb = 0;
+	spu_config.iVolume = 1024;
 #endif
 	return 0;
 }
@@ -1221,6 +1262,8 @@ static MENUITEM gui_SPUSettingsItems[] = {
 	{(char *)"IRQ fix              ", NULL, &spuirq_alter, &spuirq_show},
 #ifdef SPU_PCSXREARMED
 	{(char *)"Interpolation        ", NULL, &interpolation_alter, &interpolation_show},
+	{(char *)"Reverb               ", NULL, &reverb_alter, &reverb_show},
+	{(char *)"Master volume        ", NULL, &volume_alter, &volume_show},
 #endif
 	{(char *)"Restore defaults     ", &spu_settings_defaults, NULL, NULL},
 	{NULL, NULL, NULL, NULL},

--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -252,6 +252,14 @@ void config_load()
 		else if (!strcmp(line, "SpuUseInterpolation")) {
 			sscanf(arg, "%d", &value);
 			spu_config.iUseInterpolation = value;
+		} else if (!strcmp(line, "SpuUseReverb")) {
+			sscanf(arg, "%d", &value);
+			spu_config.iUseReverb = value;
+		} else if (!strcmp(line, "SpuVolume")) {
+			sscanf(arg, "%d", &value);
+			if (value > 1024) value = 1024;
+			if (value < 0) value = 0;
+			spu_config.iVolume = value;
 		}
 #endif
 		else if (!strcmp(line, "LastDir")) {
@@ -367,6 +375,8 @@ void config_save()
 
 #ifdef SPU_PCSXREARMED
 	fprintf(f, "SpuUseInterpolation %d\n", spu_config.iUseInterpolation);
+	fprintf(f, "SpuUseReverb %d\n", spu_config.iUseReverb);
+	fprintf(f, "SpuVolume %d\n", spu_config.iVolume);
 #endif
 
 #ifdef PSXREC
@@ -659,15 +669,8 @@ int main (int argc, char **argv)
 	strncpy(Config.LastDir, home, MAXPATHLEN); /* Defaults to home directory. */
 	Config.LastDir[MAXPATHLEN-1] = '\0';
 
-	// spu_dfxsound
-#ifdef spu_dfxsound
-	extern int iDisStereo; iDisStereo=0; // 0=stereo, 1=mono
-	extern int iUseInterpolation; iUseInterpolation=0; // 0=disabled, 1=enabled
-	extern int iUseReverb; iUseReverb=0; // 0=disabled, 1=enabled
-#endif
-
 	// senquack - added spu_pcsxrearmed plugin:
-#ifdef spu_pcsxrearmed
+#ifdef SPU_PCSXREARMED
 	//ORIGINAL PCSX ReARMed SPU defaults (put here for reference):
 	//	spu_config.iUseReverb = 1;
 	//	spu_config.iUseInterpolation = 1;
@@ -690,7 +693,7 @@ int main (int argc, char **argv)
 	spu_config.iUseReverb = 0;
 	spu_config.iUseInterpolation = 0;
 	spu_config.iXAPitch = 0;
-	spu_config.iVolume = 768;             // 1024 is max volume (1.0)
+	spu_config.iVolume = 1024;            // 1024 is max volume
 	spu_config.iUseThread = 0;            // no effect if only 1 core is detected
 	spu_config.iUseFixedUpdates = 1;      // This is always set to 1 in libretro's pcsxReARMed
 	spu_config.iTempo = 1;                // see note below
@@ -996,7 +999,7 @@ int main (int argc, char **argv)
 			spu_config.iUseInterpolation = val;
 		}
 
-		// Set volume level of SPU, 0-1024, default is 768.
+		// Set volume level of SPU, 0-1024
 		//  If value is 0, sound will be disabled.
 		if (strcmp(argv[i],"-volume") == 0) {
 			int val = -1;

--- a/src/psxcommon.cpp
+++ b/src/psxcommon.cpp
@@ -1,0 +1,31 @@
+/***************************************************************************
+ *   Copyright (C) 2007 Ryan Schultz, PCSX-df Team, PCSX team              *
+ *   schultz.ryan@gmail.com, http://rschultz.ath.cx/code.php               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Steet, Fifth Floor, Boston, MA 02111-1307 USA.            *
+ ***************************************************************************/
+
+#include "psxcommon.h"
+#include "plugin_lib/plugin_lib.h"
+
+void EmuUpdate()
+{
+	pl_frame_limit();
+
+	// Update controls
+	// NOTE: this is point of control transfer to frontend menu
+	pad_update();
+}

--- a/src/psxcommon.h
+++ b/src/psxcommon.h
@@ -77,6 +77,49 @@ enum {
 	PSXTYPE_PAL  = 1
 };
 
+
+// SPU update frequency  (accomodates slow devices)
+// Values used for Config.SpuUpdateFreq
+enum {
+	SPU_UPDATE_FREQ_MIN = 0,
+	SPU_UPDATE_FREQ_1   = 0,
+	SPU_UPDATE_FREQ_2   = 1,
+	SPU_UPDATE_FREQ_4   = 2,
+	SPU_UPDATE_FREQ_8   = 3,
+	SPU_UPDATE_FREQ_16  = 4,
+	SPU_UPDATE_FREQ_32  = 5,
+	SPU_UPDATE_FREQ_MAX = SPU_UPDATE_FREQ_32
+};
+
+#ifndef SPU_UPDATE_FREQ_DEFAULT
+#define SPU_UPDATE_FREQ_DEFAULT SPU_UPDATE_FREQ_1
+#endif
+
+// Forced XA audio update frequency (accomodates slow devices)
+// Values used for Config.ForcedXAUpdates
+enum {
+	FORCED_XA_UPDATES_MIN     = 0,
+	FORCED_XA_UPDATES_OFF     = 0,
+	FORCED_XA_UPDATES_AUTO    = 1,
+	FORCED_XA_UPDATES_2       = 2,
+	FORCED_XA_UPDATES_4       = 3,
+	FORCED_XA_UPDATES_8       = 4,
+	FORCED_XA_UPDATES_16      = 5,
+	FORCED_XA_UPDATES_32      = 6,
+	FORCED_XA_UPDATES_MAX     = FORCED_XA_UPDATES_32
+};
+
+#ifndef FORCED_XA_UPDATES_DEFAULT
+#define FORCED_XA_UPDATES_DEFAULT FORCED_XA_UPDATES_OFF
+#endif
+
+enum {
+	FRAMESKIP_MIN  = -1,
+	FRAMESKIP_AUTO = -1,
+	FRAMESKIP_OFF  = 0,
+	FRAMESKIP_MAX  = 3
+};
+
 typedef struct {
 	char Mcd1[MAXPATHLEN];
 	char Mcd2[MAXPATHLEN];
@@ -101,19 +144,24 @@ typedef struct {
 	//           main thread blocks
 	boolean SyncAudio;
 
+	s8      SpuUpdateFreq; // Frequency of SPU updates
+	                       // 0: once per frame  1: twice per frame etc
+	                       // (Use SPU_UPDATE_FREQ_* enum to set)
+
 	//senquack - Added option to allow queuing CDREAD_INT interrupts sooner
 	//           than they'd normally be issued when SPU's XA buffer is not
 	//           full. This fixes droupouts in music/speech on slow devices.
-	boolean ForcedXAUpdates; 
+	s8      ForcedXAUpdates;
 
 	boolean ShowFps;     // Show FPS
 	boolean FrameLimit;  // Limit to NTSC/PAL framerate
+
+	s8      FrameSkip;	// -1: AUTO  0: OFF  1-3: FIXED
 
 	// Options for performance monitor
 	boolean PerfmonConsoleOutput;
 	boolean PerfmonDetailedStats;
 
-	s8      FrameSkip;	// -1: AUTO  0: OFF  1-3: FIXED
 } PcsxConfig;
 
 extern PcsxConfig Config;

--- a/src/psxcommon.h
+++ b/src/psxcommon.h
@@ -72,6 +72,11 @@ typedef uint8_t boolean;
 #define MAXPATHLEN 256
 #endif
 
+enum {
+	PSXTYPE_NTSC = 0,
+	PSXTYPE_PAL  = 1
+};
+
 typedef struct {
 	char Mcd1[MAXPATHLEN];
 	char Mcd2[MAXPATHLEN];
@@ -107,6 +112,8 @@ typedef struct {
 	// Options for performance monitor
 	boolean PerfmonConsoleOutput;
 	boolean PerfmonDetailedStats;
+
+	s8      FrameSkip;	// -1: AUTO  0: OFF  1-3: FIXED
 } PcsxConfig;
 
 extern PcsxConfig Config;
@@ -156,5 +163,6 @@ enum {
 	CPU_INTERPRETER
 }; // CPU Types
 
+void EmuUpdate();
 
 #endif /* __PSXCOMMON_H__ */

--- a/src/psxcounters.cpp
+++ b/src/psxcounters.cpp
@@ -40,7 +40,6 @@
 #include "psxcounters.h"
 #include "psxevents.h"
 #include "gpu.h"
-#include "plugin_lib/perfmon.h"
 
 /******************************************************************************/
 
@@ -355,14 +354,12 @@ void psxRcntUpdate()
             GPU_vBlank( 1, 0 );
 #endif
             setIrq( 0x01 );
+
+            // Do framelimit, frameskip, perf stats, controls, etc:
+            // NOTE: this is point of control transfer to frontend menu
+            EmuUpdate();
+
             GPU_updateLace();
-
-            // Update and display performance stats
-            pmonUpdate();
-
-            // Update controls
-            // NOTE: this is point of control transfer to frontend
-            pad_update();
 
             // If frontend called LoadState(), loading a savestate, do not
             //  proceed further: Rootcounter state has been altered.
@@ -374,7 +371,7 @@ void psxRcntUpdate()
             //senquack - PCSX Rearmed updates its SPU plugin once per emulated
             // frame. However, we target slower platforms like GCW Zero, and
             // lack auto-frameskip, so this would lead to audio dropouts. For
-            // now, we update SPU plugin twice per frame in psxevents.cpp
+            // now, we update SPU plugin twice per frame as a scheduled event.
             //SPU_async( cycle, 1 );
         }
 

--- a/src/psxcounters.cpp
+++ b/src/psxcounters.cpp
@@ -359,8 +359,6 @@ void psxRcntUpdate()
             // NOTE: this is point of control transfer to frontend menu
             EmuUpdate();
 
-            GPU_updateLace();
-
             // If frontend called LoadState(), loading a savestate, do not
             //  proceed further: Rootcounter state has been altered.
             if (rcntFreezeLoaded) {
@@ -368,11 +366,13 @@ void psxRcntUpdate()
                 return;
             }
 
+            GPU_updateLace();
+
             //senquack - PCSX Rearmed updates its SPU plugin once per emulated
-            // frame. However, we target slower platforms like GCW Zero, and
-            // lack auto-frameskip, so this would lead to audio dropouts. For
-            // now, we update SPU plugin twice per frame as a scheduled event.
-            //SPU_async( cycle, 1 );
+            // frame. However, we target slower platforms and update SPU plugin
+            // at flexible interval (scheduled event) to avoid audio dropouts.
+            if (Config.SpuUpdateFreq == SPU_UPDATE_FREQ_1)
+                SPU_async(cycle, 1);
         }
 
         // Update lace. (with InuYasha fix)

--- a/src/recompiler/mips/recompiler.cpp
+++ b/src/recompiler/mips/recompiler.cpp
@@ -25,6 +25,7 @@
  *
  */
 
+#include "plugin_lib.h"
 #include "psxcommon.h"
 #include "psxhle.h"
 #include "psxmem.h"
@@ -191,6 +192,9 @@ void clear_insn_cache(void *start, void *end, int flags)
 
 static void recRecompile()
 {
+	// Notify plugin_lib that we're recompiling (affects frameskip timing)
+	pl_dynarec_notify();
+
 	if ((u32)recMem - (u32)recMemBase >= RECMEM_SIZE_MAX )
 		recReset();
 


### PR DESCRIPTION
Adapt first parts of PCSX Rearmed's plugin lib, which gives
us accurate frame limiter and cross-plugin frameskip.
**NOTE**: Frameskip can cause gfx glitches despite it making
  effort to avoid skipping when VRAM transfers occur.
**NOTE**: New frameskip only used by 'gpulib' so for now, to
  test, must compile with USE_GPULIB=1
* Frame limiter is now on by default.
* SPU Audio Sync option can now be turned off by default.
* Rework how SPU updates and Forced XA Updates are handled,
  eliminating audio lag in FMVs or XA speech. Set new higher-freq
  defaults for each option, customized for optimal results on
  either GCW Zero or A320 platforms.
* Increase size of spu_pcsxrearmed's SDL audio buffer to match Rearmed,
  but keep it slightly less full than Rearmed default (decreases lag).
* Add Reverb, Master Volume SPU settings.  PSX master volume default
  is now full (1024) instead of 3/4 (768).
* Increase frequency of SPU update/IRQ updates to 4-per-frame
  for GCW Zero and 8-per-frame for A320.
* Fix bug in frontend SPU menu size computation macro
