### PR TITLE
mipsrec: Improve const val handling of $r0

### DIFF
--- a/src/recompiler/mips/recompiler.cpp
+++ b/src/recompiler/mips/recompiler.cpp
@@ -47,8 +47,8 @@ typedef struct {
 } iRegisters;
 
 #define IsConst(reg) (iRegs[reg].s)
-#define SetUndef(reg) do { iRegs[reg].s = 0; } while (0)
-#define SetConst(reg, val) do { iRegs[reg].s = 1; iRegs[reg].r = (val); } while (0)
+#define SetUndef(reg) do { if (reg != 0) iRegs[reg].s = 0; } while (0)
+#define SetConst(reg, val) do { if (reg != 0) { iRegs[reg].s = 1; iRegs[reg].r = (val); } } while (0)
 
 static iRegisters iRegs[32]; /* used for imm caching and back up of regs in dynarec */
 
@@ -206,6 +206,7 @@ static void recRecompile()
 
 	rec_recompile_start();
 	memset(iRegs, 0, sizeof(iRegs));
+	iRegs[0].s = 1;  // $r0 is always zero val
 
 	do {
 		psxRegs.code = *(u32 *)((char *)PSXM(pc));


### PR DESCRIPTION
At the very least, this improves recompiled BIOS code, because it uses
r0 as known-const base reg in mem accesses to first 32KB RAM.