### PR TITLE
frontend,plugin_lib: Add savestate screenshots

### DIFF
--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -64,7 +64,8 @@ all: maketree $(TARGET)
 OBJS = \
 	obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o \
 	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/psxevents.o \
-	obj/psxcommon.o obj/plugin_lib/plugin_lib.o \
+	obj/psxcommon.o \
+	obj/plugin_lib/plugin_lib.o obj/plugin_lib/pl_sshot.o \
 	obj/psxinterpreter.o \
 	obj/mdec.o obj/decode_xa.o \
 	obj/cdriso.o obj/cdrom.o obj/ppf.o \

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -49,7 +49,8 @@ all: maketree $(TARGET)
 OBJS = \
 	obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o \
 	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/psxevents.o \
-	obj/psxcommon.o obj/plugin_lib/plugin_lib.o \
+	obj/psxcommon.o \
+	obj/plugin_lib/plugin_lib.o obj/plugin_lib/pl_sshot.o \
 	obj/psxinterpreter.o \
 	obj/mdec.o obj/decode_xa.o \
 	obj/cdriso.o obj/cdrom.o obj/ppf.o \

--- a/Makefile.win32
+++ b/Makefile.win32
@@ -56,7 +56,8 @@ all: maketree $(TARGET)
 OBJS = \
 	obj/r3000a.o obj/misc.o obj/plugins.o obj/psxmem.o obj/psxhw.o \
 	obj/psxcounters.o obj/psxdma.o obj/psxbios.o obj/psxhle.o obj/psxevents.o \
-	obj/psxcommon.o obj/plugin_lib/plugin_lib.o \
+	obj/psxcommon.o \
+	obj/plugin_lib/plugin_lib.o obj/plugin_lib/pl_sshot.o \
 	obj/psxinterpreter.o \
 	obj/mdec.o obj/decode_xa.o \
 	obj/cdriso.o obj/cdrom.o obj/ppf.o \

--- a/src/misc.h
+++ b/src/misc.h
@@ -71,7 +71,17 @@ int Load(const char *ExePath);
 
 int SaveState(const char *file);
 int LoadState(const char *file);
-int CheckState(const char *file);
+int CheckState(const char *file, bool *uses_hle, bool get_sshot, u16 *sshot_image);
+
+enum {
+	CHECKSTATE_SUCCESS        = 0,
+	CHECKSTATE_ERR_OPEN       = -1,
+	CHECKSTATE_ERR_HEADER     = -2,
+	CHECKSTATE_ERR_VERSION    = -3,
+	CHECKSTATE_ERR_NO_SSHOT   = -4,
+	CHECKSTATE_ERR_READ       = -5
+};
 
 bool FileExists(const char* filename);
+int FileDate(const char* filename, char *date_str, time_t *m_time);
 #endif /* __MISC_H__ */

--- a/src/plugin_lib/pl_sshot.cpp
+++ b/src/plugin_lib/pl_sshot.cpp
@@ -1,0 +1,136 @@
+/***************************************************************************
+ * (C) PCSX4ALL team 2017                                                  *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02111-1307 USA.           *
+ ***************************************************************************/
+
+/*
+ * Screenshot functionality for plugin_lib
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "plugin_lib.h"
+
+#define RGB16(C)     ((((C)&(0x1f<<10))>>10) | (((C)&(0x1f<<5))<<1) | (((C)&(0x1f))<<11))
+#define RGB24(R,G,B) ((((R)&0xF8)<<8)|(((G)&0xFC)<<3)|(((B)&0xF8)>>3))
+
+// For embedded savestate screenshots
+// (Simple pixel-dropping downscaling.. TODO: add interpolation)
+void pl_screenshot_160x120_rgb565(uint16_t *dst)
+{
+	memset((void*)dst, 0, 160*120*2);
+	int x = pl_data.sinfo.x;
+	int y = pl_data.sinfo.y;
+	int w = pl_data.sinfo.w;
+	int h = pl_data.sinfo.h;
+	int hres = pl_data.sinfo.hres;
+	int vres = pl_data.sinfo.vres;
+	bool depth24 = pl_data.sinfo.depth24;
+	uint16_t *src = (uint16_t*)pl_data.sinfo.vram;
+	const int vram_h = 512;
+
+	if (w == 0 || h == 0)
+		return;
+
+	if (hres > 640) hres = 640;
+	if (vres > 480) vres = 480;
+	if (w > hres) w = hres;
+	if (h > vres) h = vres;
+
+	if (y + h > vram_h) {
+		if (y + h - vram_h > h / 2) {
+			// wrap
+			h -= vram_h - y;
+			y = 0;
+		} else {
+			// clip
+			h = vram_h - y;
+		}
+	}
+
+	// Only read even lines in case gpu plugin skipped rendering odd ones
+	if (vres == 480)
+		y &= ~1;
+
+	src += y * 1024 + x;
+
+	// Skip 1/2 of src lines for 240 vres, 3/4 of src lines for 480 vres
+	const int src_stride = (vres == 480) ? 1024 * 4 : 1024 * 2;
+	const int dst_stride = 160;
+
+	int scale_numer, scale_denom;
+	switch (hres) {
+		case 256:
+			scale_numer = 4;  scale_denom = 5;
+			break;
+		case 320:
+			scale_numer = 1;  scale_denom = 1;
+			break;
+		case 368:
+			scale_numer = 8;  scale_denom = 7;
+			break;
+		case 384:
+			scale_numer = 6;  scale_denom = 5;
+			break;
+		case 512:
+			scale_numer = 8;  scale_denom = 5;
+			break;
+		case 640:
+			scale_numer = 2;  scale_denom = 1;
+			break;
+		default:
+			printf("Warning: unrecognized hres %d in %s()\n", hres, __func__);
+			return;
+	}
+
+	int start_i = 0, end_i = 160;
+	int start_j = 0, end_j = 120;
+
+	// Width centering
+	if (w < hres) {
+		int tmp = ((hres - w) / 2) * scale_denom / scale_numer;
+		start_i += tmp / 2;
+		end_i -= tmp / 2;
+	}
+
+	// Height centering
+	if (h < vres) {
+		int tmp = ((vres - h) / 2) / ((vres == 480) ? 2 : 1);
+		start_j += tmp / 2;
+		end_j -= tmp / 2;
+	}
+
+	dst += start_j * dst_stride + start_i;
+
+	for (int j=start_j; j < end_j; ++j) {
+		if (depth24) {
+			for (int i=start_i; i < end_i; ++i) {
+				int src_off = i * 2 * scale_numer / scale_denom;
+				uint8_t *srcpix8 = (uint8_t*)src + src_off * 3;
+				dst[i] = RGB24(srcpix8[0], srcpix8[1], srcpix8[2]);
+			}
+		} else {
+			for (int i=start_i; i < end_i; ++i) {
+				int src_off = i * 2 * scale_numer / scale_denom;
+				dst[i] = RGB16(src[src_off]);
+			}
+		}
+		dst += dst_stride;
+		src += src_stride;
+	}
+}

--- a/src/plugin_lib/plugin_lib.h
+++ b/src/plugin_lib/plugin_lib.h
@@ -65,4 +65,7 @@ static inline void pl_dynarec_notify(void)
 	pl_data.dynarec_compiled = true;
 }
 
+// In pl_sshot.cpp
+void pl_screenshot_160x120_rgb565(u16 *dst);
+
 #endif // PLUGIN_LIB_H

--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -76,10 +76,10 @@ static void pcsx4all_exit(void)
 
 static char *home = NULL;
 static char homedir[PATH_MAX] =		"./.pcsx4all";
-static char sstatesdir[PATH_MAX] =	"./.pcsx4all/sstates";
 static char memcardsdir[PATH_MAX] =	"./.pcsx4all/memcards";
 static char biosdir[PATH_MAX] =		"./.pcsx4all/bios";
 static char patchesdir[PATH_MAX] =	"./.pcsx4all/patches";
+char sstatesdir[PATH_MAX] = "./.pcsx4all/sstates";
 
 #ifdef __WIN32__
 	#define MKDIR(A) mkdir(A)
@@ -109,8 +109,6 @@ static void setup_paths()
 	MKDIR(biosdir);
 	MKDIR(patchesdir);
 }
-
-int saveslot = 0;
 
 void probe_lastdir()
 {
@@ -407,10 +405,10 @@ void config_save()
 }
 
 // Returns 0: success, -1: failure
-int state_load()
+int state_load(int slot)
 {
 	char savename[512];
-	sprintf(savename, "%s/%s.%d.sav", sstatesdir, CdromId, saveslot);
+	sprintf(savename, "%s/%s.%d.sav", sstatesdir, CdromId, slot);
 
 	if (FileExists(savename)) {
 		return LoadState(savename);
@@ -420,10 +418,10 @@ int state_load()
 }
 
 // Returns 0: success, -1: failure
-int state_save()
+int state_save(int slot)
 {
 	char savename[512];
-	sprintf(savename, "%s/%s.%d.sav", sstatesdir, CdromId, saveslot);
+	sprintf(savename, "%s/%s.%d.sav", sstatesdir, CdromId, slot);
 
 	return SaveState(savename);
 }

--- a/src/port/sdl/port.h
+++ b/src/port/sdl/port.h
@@ -36,8 +36,8 @@ void port_printf(int x, int y, const char *text);
 
 extern unsigned short *SCREEN;
 
-int state_load();
-int state_save();
+int state_load(int slot);
+int state_save(int slot);
 
 int SelectGame();
 int GameMenu();


### PR DESCRIPTION
Savestates now contain an embedded 160x120 rgb565 image towards
the beginning of the file. This is 38400 bytes, slightly larger
than the 36864 bytes reserved space present but unused in old
savestates. Compatibility is preserved when older saves are
detected. Incremented sstate version # to 0x8b410006.

Added simple non-interpolating 160x120 rescaler to plugin_lib,
eventually we can use SDL_gfx rotozoomer or something better.

Frontend savestates are now in their own submenus and show
preview images and dates. Menu automatically selects newest
file when loading menu for first time.

CheckState() in misc.cpp has improved error handling and features
to help accomplish all this.