### PR TITLE
psxbios: Fix numerous issues with Digimon World on HLE Bios

### DIFF
--- a/src/psxbios.cpp
+++ b/src/psxbios.cpp
@@ -382,7 +382,12 @@ void psxBios_strcat(void) { // 0x15
 #ifdef PSXBIOS_LOG
 	PSXBIOS_LOG("psxBios_%s: %s, %s\n", biosA0n[0x15], Ra0, Ra1);
 #endif
-
+	if (a0 == 0 || a1 == 0)
+	{
+		v0 = 0;
+		pc0 = ra;
+		return;
+	}
 	while (*p1++);
 	--p1;
 	while ((*p1++ = *p2++) != '\0');
@@ -1656,12 +1661,18 @@ void psxBios_PAD_init(void) { // 15
 #ifdef PSXBIOS_LOG
 	PSXBIOS_LOG("psxBios_%s\n", biosB0n[0x15]);
 #endif
-
+	if (!(a0 == 0x20000000 || a0 == 0x20000001))
+	{
+		v0 = 0;
+		pc0 = ra;
+		return;
+	}
 	ResetIoCycle();
 	psxHwWrite16(0x1f801074, (u16)(psxHwRead16(0x1f801074) | 0x1));
 	pad_buf = (int*)Ra1;
 	*pad_buf = -1;
 	psxRegs.CP0.n.Status |= 0x401;
+	v0 = 2;
 	pc0 = ra;
 }
 
@@ -2867,7 +2878,9 @@ void psxBiosException(void) {
 		case 0x20: // Syscall
 			switch (a0) {
 				case 1: // EnterCritical - disable irq's
-					psxRegs.CP0.n.Status&=~0x404; 
+					/* Fixes Medievil 2 not loading up new game, Digimon World not booting up and possibly others */
+					v0 = (psxRegs.CP0.n.Status & 0x404) == 0x404;
+					psxRegs.CP0.n.Status &= ~0x404;
 					//v0=1;	// HDHOSHY experimental patch: Spongebob, Coldblood, fearEffect, Medievil2, Martian Gothic
 					break;
 


### PR DESCRIPTION
On HLE BIOS, Digimon World would refuse to boot up.
The issue turned out to be an issue with strcat not being compliant with the official BIOS behaviour,
as well as an issue with EnterCritical not returning anything to v0.
This also properly addresses the crash issue in Medievil 2, as the experimental patch
was always returning 1, when it should only do so if both bits (bit 2 and bit 10) were properly set.

Another issue it addresses is lack of input in Digimon World after booting up.

The issue turned out to be psxBios_PAD_init, which the game erroneously with invalid types,
resulting in no input. This was fixed by only allowing some types, as documented by nocash.

This doesn't fix the memory card issue in Digimon World. I have a bunch of patches for that (based on upstream PCSXR code) but there are still some issues with some games like Nuclear Strike. (see https://github.com/gameblabla/pcsx4all/issues/8 )
If i cannot address the later though, i might merge the related patches as is though, since it also fixes other games but not for this pull request for now.