### PR TITLE
Fix build of src/cdrom.cpp

### DIFF
--- a/src/cdrom.cpp
+++ b/src/cdrom.cpp
@@ -1352,7 +1352,7 @@ void cdrWrite1(unsigned char rt) {
 			set_loc[i] = btoi(cdr.Param[i]);
 
 		i = msf2sec(cdr.SetSectorPlay);
-		i = abs(i - msf2sec(set_loc));
+		i = abs(static_cast<long>(i - msf2sec(set_loc)));
 		if (i > 16)
 			cdr.Seeked = SEEK_PENDING;
 


### PR DESCRIPTION
Avoid a build error with g++8. The argument to std::abs() is "int", but there's no std::abs(int) prototype so g++ doesn't know which cast to apply. Fix this by casting to long.