### PR TITLE
fix for obj/gpu/gpu_unai not existing

### DIFF
--- a/Makefile.gcw0
+++ b/Makefile.gcw0
@@ -111,6 +111,7 @@ endif
 #  Fixes many game incompatibilities and centralizes/improves many
 #  things that once were the responsibility of individual GPU plugins.
 #  NOTE: For now, only GPU Unai has been adapted.
+OBJDIRS += obj/gpu/$(GPU)
 ifeq ($(USE_GPULIB),1)
 CFLAGS += -DUSE_GPULIB
 OBJDIRS += obj/gpu/gpulib


### PR DESCRIPTION
Hey Dmitry, 
we've been looking at this for the new rg-350 handheld, and this little patch fixes for the condition when unai gpu is selected (default) but it can't write to the non existent path.
Cheers,
Mat